### PR TITLE
Large net training pipeline

### DIFF
--- a/large.yaml
+++ b/large.yaml
@@ -1,12 +1,17 @@
 training:
   steps:
+    #
+    # S1 
+    #
     - convert:
         binpack: official-stockfish/master-binpacks/fishpack32.binpack
         checkpoint2nnue:
           - --features=HalfKAv2_hm^
+          - --l1=3072
           - --ft_compression=leb128
         optimize:
           - --features=HalfKAv2_hm
+          - --l1=3072
           - --ft_optimize_count=100000
           - --ft_optimize
           - --ft_compression=leb128
@@ -14,40 +19,40 @@ training:
         - hf:
             owner: official-stockfish
             repo: master-binpacks
-        - hf:
-            owner: vondele
-            repo: from_classical
       run:
         binpacks:
-          - vondele/from_classical/from_classical_05_pv-2_diff-100_nodes-5000.binpack
-          - vondele/from_classical/from_classical_04_pv-2_diff-100_nodes-5000.binpack
-          - vondele/from_classical/from_classical_03_pv-2_diff-100_nodes-5000.binpack
-        max_epochs: 800
-        repetitions: 2
+          - official-stockfish/master-binpacks/nodes5000pv2_UHO.binpack
+          - official-stockfish/master-binpacks/nodes5000pv2_UHO.binpack # 2x
+          - official-stockfish/master-binpacks/wrongIsRight_nodes5000pv2.binpack
+          - official-stockfish/master-binpacks/multinet_pv-2_diff-100_nodes-5000.binpack
+          - official-stockfish/master-binpacks/dfrc_n5000.binpack
+        max_epochs: 400
+        repetitions: 1
         other_options:
           - --batch-size=16384
           - --features=HalfKAv2_hm^
+          - --l1=3072
+          - --lr=4.375e-4
+          - --gamma=0.995
           - --start-lambda=1.0
-          - --end-lambda=0.7
-          - --gamma=0.997
-          - --lr=0.0012
-          - --in-scaling=317
-          - --out-scaling=379
-          - --in-offset=269
-          - --out-offset=253
-          - --pow-exp=2.5
+          - --end-lambda=1.0
           - --random-fen-skipping=10
         resume: none
       trainer:
         owner: official-stockfish
         sha: ba499f2819dab17ec1784ea6522ee004ff32fd57
+    #
+    # S2 
+    #
     - convert:
         binpack: official-stockfish/master-binpacks/fishpack32.binpack
         checkpoint2nnue:
           - --features=HalfKAv2_hm^
+          - --l1=3072
           - --ft_compression=leb128
         optimize:
           - --features=HalfKAv2_hm
+          - --l1=3072
           - --ft_optimize_count=100000
           - --ft_optimize
           - --ft_compression=leb128
@@ -57,38 +62,42 @@ training:
             repo: master-binpacks
         - hf:
             owner: vondele
-            repo: from_classical
+            repo: from_kaggle_2
       run:
         binpacks:
-          - vondele/from_classical/from_classical_05_pv-2_diff-100_nodes-5000.binpack
-          - vondele/from_classical/from_classical_04_pv-2_diff-100_nodes-5000.binpack
-          - vondele/from_classical/from_classical_03_pv-2_diff-100_nodes-5000.binpack
+          - vondele/from_kaggle_2/T60T70wIsRightFarseerT60T74T75T76.split_0.binpack
+          - vondele/from_kaggle_2/T60T70wIsRightFarseerT60T74T75T76.split_1.binpack
+          - vondele/from_kaggle_2/T60T70wIsRightFarseerT60T74T75T76.split_2.binpack
+          - vondele/from_kaggle_2/T60T70wIsRightFarseerT60T74T75T76.split_3.binpack
+          - vondele/from_kaggle_2/T60T70wIsRightFarseerT60T74T75T76.split_4.binpack
         max_epochs: 800
-        repetitions: 2
+        repetitions: 3
         other_options:
           - --batch-size=16384
           - --features=HalfKAv2_hm^
+          - --l1=3072
+          - --lr=4.375e-4
+          - --gamma=0.995
           - --start-lambda=1.0
-          - --end-lambda=0.7
-          - --gamma=0.997
-          - --lr=0.0012
-          - --in-scaling=317
-          - --out-scaling=379
-          - --in-offset=269
-          - --out-offset=253
-          - --pow-exp=2.5
+          - --end-lambda=0.75
           - --random-fen-skipping=10
+          - --early-fen-skipping=12
         resume: previous_model
       trainer:
         owner: official-stockfish
         sha: ba499f2819dab17ec1784ea6522ee004ff32fd57
+    #
+    # S3 
+    #
     - convert:
         binpack: official-stockfish/master-binpacks/fishpack32.binpack
         checkpoint2nnue:
           - --features=HalfKAv2_hm^
+          - --l1=3072
           - --ft_compression=leb128
         optimize:
           - --features=HalfKAv2_hm
+          - --l1=3072
           - --ft_optimize_count=100000
           - --ft_optimize
           - --ft_compression=leb128
@@ -97,25 +106,378 @@ training:
             owner: official-stockfish
             repo: master-binpacks
         - hf:
-            owner: vondele
-            repo: from_classical
+            owner: linrock
+            repo: test60
+        - hf:
+            owner: linrock
+            repo: test77
+        - hf:
+            owner: linrock
+            repo: test78
+        - hf:
+            owner: linrock
+            repo: test79
+        - hf:
+            owner: linrock
+            repo: test80-2022
+        - hf:
+            owner: linrock
+            repo: test80-2023
+        - hf:
+            owner: linrock
+            repo: test80-2024
+        - hf:
+            owner: linrock
+            repo: dual-nnue
       run:
         binpacks:
-          - official-stockfish/master-binpacks/fishpack32.binpack
-        max_epochs: 100
+          - kaggle/leela96-filt-v2.min.binpack
+          - linrock/test60/test60-2021-11-nov-12tb7p.min-v2.binpack
+          - linrock/test60/test60-2021-12-dec-12tb7p.min-v2.binpack
+          - linrock/test78/test78-2022-01-to-05-jantomay-16tb7p.v6-dd.min.binpack
+          - linrock/test78/test78-2022-06-to-09-juntosep-16tb7p.v6-dd.min.binpack
+          - linrock/test77/test77-2021-12-dec-16tb7p.v6-dd.min.binpack
+          - linrock/test78/test78-2022-01-to-05-jantomay-16tb7p.v6-dd.min.binpack
+          - linrock/test78/test78-2022-06-to-09-juntosep-16tb7p.v6-dd.min.binpack
+          - linrock/test78/test78-2022-01-to-05-jantomay-16tb7p.v6-dd.min.binpack
+          - linrock/test78/test78-2022-06-to-09-juntosep-16tb7p.v6-dd.min.binpack
+          - linrock/test79/test79-2022-04-apr-16tb7p.v6-dd.min.binpack
+          - linrock/test79/test79-2022-05-may-16tb7p.v6-dd.min.binpack
+          - linrock/test80-2022/test80-2022-06-jun-16tb7p.v6-dd.min.binpack
+          - linrock/test80-2022/test80-2022-07-jul-16tb7p.v6-dd.min.binpack
+          - linrock/test80-2022/test80-2022-08-aug-16tb7p.v6-dd.min.binpack
+          - linrock/test80-2022/test80-2022-09-sep-16tb7p.v6-dd.min.binpack
+          - linrock/test80-2022/test80-2022-10-oct-16tb7p.v6-dd.binpack
+          - linrock/test80-2022/test80-2022-11-nov-16tb7p.v6-dd.min.binpack
+          - linrock/test80-2023/test80-2023-01-jan-16tb7p.v6-sk20.min.binpack
+          - linrock/test80-2023/test80-2023-02-feb-16tb7p.v6-dd.min.binpack #sk20?
+          - linrock/test80-2023/test80-2023-03-mar-2tb7p.v6-sk16.min.binpack
+          - linrock/test80-2023/test80-2023-04-apr-2tb7p.v6-sk16.min.binpack
+          - linrock/test80-2023/test80-2023-05-may-2tb7p.v6.min.binpack
+          - linrock/test80-2023/test80-2023-06-jun-2tb7p.min-v2.v6.binpack
+          - linrock/test80-2023/test80-2023-07-jul-2tb7p.min-v2.v6.binpack
+          - linrock/test80-2023/test80-2023-08-aug-2tb7p.v6.min.binpack
+          - linrock/test80-2023/test80-2023-09-sep-2tb7p.min-v2.v6.binpack 
+          - linrock/test80-2023/test80-2023-10-oct-2tb7p.min-v2.v6.binpack
+          - linrock/test80-2023/test80-2023-11-nov-2tb7p.min-v2.v6.binpack
+          - linrock/test80-2023/test80-2023-12-dec-2tb7p.min-v2.v6.binpack
+          - linrock/test80-2024/test80-2024-01-jan-2tb7p.min-v2.v6.binpack
+          - linrock/test80-2024/test80-2024-02-feb-2tb7p.min-v2.v6.binpack
+        max_epochs: 800
+        repetitions: 3
         other_options:
           - --batch-size=16384
           - --features=HalfKAv2_hm^
-          - --start-lambda=0.7
-          - --end-lambda=0.7
-          - --gamma=0.997
-          - --lr=0.000012
-          - --in-scaling=317
-          - --out-scaling=379
-          - --in-offset=269
-          - --out-offset=253
-          - --pow-exp=2.5
+          - --l1=3072
+          - --lr=0.0010783148702050778
+          - --gamma=0.994446435229841
+          - --pow-exp=2.442037790427722
+          - --qp-asymmetry=0.15795949371005746
+          - --start-lambda=0.8460635942002347
+          - --end-lambda=0.7490913625693039
+          - --in-scaling=294.7193839807687
+          - --out-scaling=364.552099066772
+          - --in-offset=281.4186220835457
+          - --out-offset=279.93991915496105
           - --random-fen-skipping=10
+          - --early-fen-skipping=28
+        resume: previous_model
+      trainer:
+        owner: official-stockfish
+        sha: ba499f2819dab17ec1784ea6522ee004ff32fd57
+    #
+    # S4 repeat S3
+    #
+    - convert:
+        binpack: official-stockfish/master-binpacks/fishpack32.binpack
+        checkpoint2nnue:
+          - --features=HalfKAv2_hm^
+          - --l1=3072
+          - --ft_compression=leb128
+        optimize:
+          - --features=HalfKAv2_hm
+          - --l1=3072
+          - --ft_optimize_count=100000
+          - --ft_optimize
+          - --ft_compression=leb128
+      datasets:
+        - hf:
+            owner: official-stockfish
+            repo: master-binpacks
+        - hf:
+            owner: linrock
+            repo: test60
+        - hf:
+            owner: linrock
+            repo: test77
+        - hf:
+            owner: linrock
+            repo: test78
+        - hf:
+            owner: linrock
+            repo: test79
+        - hf:
+            owner: linrock
+            repo: test80-2022
+        - hf:
+            owner: linrock
+            repo: test80-2023
+        - hf:
+            owner: linrock
+            repo: test80-2024
+        - hf:
+            owner: linrock
+            repo: dual-nnue
+      run:
+        binpacks:
+          - kaggle/leela96-filt-v2.min.binpack
+          - linrock/test60/test60-2021-11-nov-12tb7p.min-v2.binpack
+          - linrock/test60/test60-2021-12-dec-12tb7p.min-v2.binpack
+          - linrock/test78/test78-2022-01-to-05-jantomay-16tb7p.v6-dd.min.binpack
+          - linrock/test78/test78-2022-06-to-09-juntosep-16tb7p.v6-dd.min.binpack
+          - linrock/test77/test77-2021-12-dec-16tb7p.v6-dd.min.binpack
+          - linrock/test78/test78-2022-01-to-05-jantomay-16tb7p.v6-dd.min.binpack
+          - linrock/test78/test78-2022-06-to-09-juntosep-16tb7p.v6-dd.min.binpack
+          - linrock/test78/test78-2022-01-to-05-jantomay-16tb7p.v6-dd.min.binpack
+          - linrock/test78/test78-2022-06-to-09-juntosep-16tb7p.v6-dd.min.binpack
+          - linrock/test79/test79-2022-04-apr-16tb7p.v6-dd.min.binpack
+          - linrock/test79/test79-2022-05-may-16tb7p.v6-dd.min.binpack
+          - linrock/test80-2022/test80-2022-06-jun-16tb7p.v6-dd.min.binpack
+          - linrock/test80-2022/test80-2022-07-jul-16tb7p.v6-dd.min.binpack
+          - linrock/test80-2022/test80-2022-08-aug-16tb7p.v6-dd.min.binpack
+          - linrock/test80-2022/test80-2022-09-sep-16tb7p.v6-dd.min.binpack
+          - linrock/test80-2022/test80-2022-10-oct-16tb7p.v6-dd.binpack
+          - linrock/test80-2022/test80-2022-11-nov-16tb7p.v6-dd.min.binpack
+          - linrock/test80-2023/test80-2023-01-jan-16tb7p.v6-sk20.min.binpack
+          - linrock/test80-2023/test80-2023-02-feb-16tb7p.v6-dd.min.binpack #sk20?
+          - linrock/test80-2023/test80-2023-03-mar-2tb7p.v6-sk16.min.binpack
+          - linrock/test80-2023/test80-2023-04-apr-2tb7p.v6-sk16.min.binpack
+          - linrock/test80-2023/test80-2023-05-may-2tb7p.v6.min.binpack
+          - linrock/test80-2023/test80-2023-06-jun-2tb7p.min-v2.v6.binpack
+          - linrock/test80-2023/test80-2023-07-jul-2tb7p.min-v2.v6.binpack
+          - linrock/test80-2023/test80-2023-08-aug-2tb7p.v6.min.binpack
+          - linrock/test80-2023/test80-2023-09-sep-2tb7p.min-v2.v6.binpack 
+          - linrock/test80-2023/test80-2023-10-oct-2tb7p.min-v2.v6.binpack
+          - linrock/test80-2023/test80-2023-11-nov-2tb7p.min-v2.v6.binpack
+          - linrock/test80-2023/test80-2023-12-dec-2tb7p.min-v2.v6.binpack
+          - linrock/test80-2024/test80-2024-01-jan-2tb7p.min-v2.v6.binpack
+          - linrock/test80-2024/test80-2024-02-feb-2tb7p.min-v2.v6.binpack
+        max_epochs: 800
+        repetitions: 3
+        other_options:
+          - --batch-size=16384
+          - --features=HalfKAv2_hm^
+          - --l1=3072
+          - --lr=0.0010783148702050778
+          - --gamma=0.994446435229841
+          - --pow-exp=2.442037790427722
+          - --qp-asymmetry=0.15795949371005746
+          - --start-lambda=0.8460635942002347
+          - --end-lambda=0.7490913625693039
+          - --in-scaling=294.7193839807687
+          - --out-scaling=364.552099066772
+          - --in-offset=281.4186220835457
+          - --out-offset=279.93991915496105
+          - --random-fen-skipping=10
+          - --early-fen-skipping=28
+        resume: previous_model
+      trainer:
+        owner: official-stockfish
+        sha: ba499f2819dab17ec1784ea6522ee004ff32fd57
+    #
+    # S5 repeat S4
+    #
+    - convert:
+        binpack: official-stockfish/master-binpacks/fishpack32.binpack
+        checkpoint2nnue:
+          - --features=HalfKAv2_hm^
+          - --l1=3072
+          - --ft_compression=leb128
+        optimize:
+          - --features=HalfKAv2_hm
+          - --l1=3072
+          - --ft_optimize_count=100000
+          - --ft_optimize
+          - --ft_compression=leb128
+      datasets:
+        - hf:
+            owner: official-stockfish
+            repo: master-binpacks
+        - hf:
+            owner: linrock
+            repo: test60
+        - hf:
+            owner: linrock
+            repo: test77
+        - hf:
+            owner: linrock
+            repo: test78
+        - hf:
+            owner: linrock
+            repo: test79
+        - hf:
+            owner: linrock
+            repo: test80-2022
+        - hf:
+            owner: linrock
+            repo: test80-2023
+        - hf:
+            owner: linrock
+            repo: test80-2024
+        - hf:
+            owner: linrock
+            repo: dual-nnue
+      run:
+        binpacks:
+          - kaggle/leela96-filt-v2.min.binpack
+          - linrock/test60/test60-2021-11-nov-12tb7p.min-v2.binpack
+          - linrock/test60/test60-2021-12-dec-12tb7p.min-v2.binpack
+          - linrock/test78/test78-2022-01-to-05-jantomay-16tb7p.v6-dd.min.binpack
+          - linrock/test78/test78-2022-06-to-09-juntosep-16tb7p.v6-dd.min.binpack
+          - linrock/test77/test77-2021-12-dec-16tb7p.v6-dd.min.binpack
+          - linrock/test78/test78-2022-01-to-05-jantomay-16tb7p.v6-dd.min.binpack
+          - linrock/test78/test78-2022-06-to-09-juntosep-16tb7p.v6-dd.min.binpack
+          - linrock/test78/test78-2022-01-to-05-jantomay-16tb7p.v6-dd.min.binpack
+          - linrock/test78/test78-2022-06-to-09-juntosep-16tb7p.v6-dd.min.binpack
+          - linrock/test79/test79-2022-04-apr-16tb7p.v6-dd.min.binpack
+          - linrock/test79/test79-2022-05-may-16tb7p.v6-dd.min.binpack
+          - linrock/test80-2022/test80-2022-06-jun-16tb7p.v6-dd.min.binpack
+          - linrock/test80-2022/test80-2022-07-jul-16tb7p.v6-dd.min.binpack
+          - linrock/test80-2022/test80-2022-08-aug-16tb7p.v6-dd.min.binpack
+          - linrock/test80-2022/test80-2022-09-sep-16tb7p.v6-dd.min.binpack
+          - linrock/test80-2022/test80-2022-10-oct-16tb7p.v6-dd.binpack
+          - linrock/test80-2022/test80-2022-11-nov-16tb7p.v6-dd.min.binpack
+          - linrock/test80-2023/test80-2023-01-jan-16tb7p.v6-sk20.min.binpack
+          - linrock/test80-2023/test80-2023-02-feb-16tb7p.v6-dd.min.binpack #sk20?
+          - linrock/test80-2023/test80-2023-03-mar-2tb7p.v6-sk16.min.binpack
+          - linrock/test80-2023/test80-2023-04-apr-2tb7p.v6-sk16.min.binpack
+          - linrock/test80-2023/test80-2023-05-may-2tb7p.v6.min.binpack
+          - linrock/test80-2023/test80-2023-06-jun-2tb7p.min-v2.v6.binpack
+          - linrock/test80-2023/test80-2023-07-jul-2tb7p.min-v2.v6.binpack
+          - linrock/test80-2023/test80-2023-08-aug-2tb7p.v6.min.binpack
+          - linrock/test80-2023/test80-2023-09-sep-2tb7p.min-v2.v6.binpack 
+          - linrock/test80-2023/test80-2023-10-oct-2tb7p.min-v2.v6.binpack
+          - linrock/test80-2023/test80-2023-11-nov-2tb7p.min-v2.v6.binpack
+          - linrock/test80-2023/test80-2023-12-dec-2tb7p.min-v2.v6.binpack
+          - linrock/test80-2024/test80-2024-01-jan-2tb7p.min-v2.v6.binpack
+          - linrock/test80-2024/test80-2024-02-feb-2tb7p.min-v2.v6.binpack
+        max_epochs: 800
+        repetitions: 3
+        other_options:
+          - --batch-size=16384
+          - --features=HalfKAv2_hm^
+          - --l1=3072
+          - --lr=0.0010783148702050778
+          - --gamma=0.994446435229841
+          - --pow-exp=2.442037790427722
+          - --qp-asymmetry=0.15795949371005746
+          - --start-lambda=0.8460635942002347
+          - --end-lambda=0.7490913625693039
+          - --in-scaling=294.7193839807687
+          - --out-scaling=364.552099066772
+          - --in-offset=281.4186220835457
+          - --out-offset=279.93991915496105
+          - --random-fen-skipping=10
+          - --early-fen-skipping=28
+        resume: previous_model
+      trainer:
+        owner: official-stockfish
+        sha: ba499f2819dab17ec1784ea6522ee004ff32fd57
+    #
+    # S6 repeat S5
+    #
+    - convert:
+        binpack: official-stockfish/master-binpacks/fishpack32.binpack
+        checkpoint2nnue:
+          - --features=HalfKAv2_hm^
+          - --l1=3072
+          - --ft_compression=leb128
+        optimize:
+          - --features=HalfKAv2_hm
+          - --l1=3072
+          - --ft_optimize_count=100000
+          - --ft_optimize
+          - --ft_compression=leb128
+      datasets:
+        - hf:
+            owner: official-stockfish
+            repo: master-binpacks
+        - hf:
+            owner: linrock
+            repo: test60
+        - hf:
+            owner: linrock
+            repo: test77
+        - hf:
+            owner: linrock
+            repo: test78
+        - hf:
+            owner: linrock
+            repo: test79
+        - hf:
+            owner: linrock
+            repo: test80-2022
+        - hf:
+            owner: linrock
+            repo: test80-2023
+        - hf:
+            owner: linrock
+            repo: test80-2024
+        - hf:
+            owner: linrock
+            repo: dual-nnue
+      run:
+        binpacks:
+          - kaggle/leela96-filt-v2.min.binpack
+          - linrock/test60/test60-2021-11-nov-12tb7p.min-v2.binpack
+          - linrock/test60/test60-2021-12-dec-12tb7p.min-v2.binpack
+          - linrock/test78/test78-2022-01-to-05-jantomay-16tb7p.v6-dd.min.binpack
+          - linrock/test78/test78-2022-06-to-09-juntosep-16tb7p.v6-dd.min.binpack
+          - linrock/test77/test77-2021-12-dec-16tb7p.v6-dd.min.binpack
+          - linrock/test78/test78-2022-01-to-05-jantomay-16tb7p.v6-dd.min.binpack
+          - linrock/test78/test78-2022-06-to-09-juntosep-16tb7p.v6-dd.min.binpack
+          - linrock/test78/test78-2022-01-to-05-jantomay-16tb7p.v6-dd.min.binpack
+          - linrock/test78/test78-2022-06-to-09-juntosep-16tb7p.v6-dd.min.binpack
+          - linrock/test79/test79-2022-04-apr-16tb7p.v6-dd.min.binpack
+          - linrock/test79/test79-2022-05-may-16tb7p.v6-dd.min.binpack
+          - linrock/test80-2022/test80-2022-06-jun-16tb7p.v6-dd.min.binpack
+          - linrock/test80-2022/test80-2022-07-jul-16tb7p.v6-dd.min.binpack
+          - linrock/test80-2022/test80-2022-08-aug-16tb7p.v6-dd.min.binpack
+          - linrock/test80-2022/test80-2022-09-sep-16tb7p.v6-dd.min.binpack
+          - linrock/test80-2022/test80-2022-10-oct-16tb7p.v6-dd.binpack
+          - linrock/test80-2022/test80-2022-11-nov-16tb7p.v6-dd.min.binpack
+          - linrock/test80-2023/test80-2023-01-jan-16tb7p.v6-sk20.min.binpack
+          - linrock/test80-2023/test80-2023-02-feb-16tb7p.v6-dd.min.binpack #sk20?
+          - linrock/test80-2023/test80-2023-03-mar-2tb7p.v6-sk16.min.binpack
+          - linrock/test80-2023/test80-2023-04-apr-2tb7p.v6-sk16.min.binpack
+          - linrock/test80-2023/test80-2023-05-may-2tb7p.v6.min.binpack
+          - linrock/test80-2023/test80-2023-06-jun-2tb7p.min-v2.v6.binpack
+          - linrock/test80-2023/test80-2023-07-jul-2tb7p.min-v2.v6.binpack
+          - linrock/test80-2023/test80-2023-08-aug-2tb7p.v6.min.binpack
+          - linrock/test80-2023/test80-2023-09-sep-2tb7p.min-v2.v6.binpack 
+          - linrock/test80-2023/test80-2023-10-oct-2tb7p.min-v2.v6.binpack
+          - linrock/test80-2023/test80-2023-11-nov-2tb7p.min-v2.v6.binpack
+          - linrock/test80-2023/test80-2023-12-dec-2tb7p.min-v2.v6.binpack
+          - linrock/test80-2024/test80-2024-01-jan-2tb7p.min-v2.v6.binpack
+          - linrock/test80-2024/test80-2024-02-feb-2tb7p.min-v2.v6.binpack
+        max_epochs: 800
+        repetitions: 3
+        other_options:
+          - --batch-size=16384
+          - --features=HalfKAv2_hm^
+          - --l1=3072
+          - --lr=0.0010783148702050778
+          - --gamma=0.994446435229841
+          - --pow-exp=2.442037790427722
+          - --qp-asymmetry=0.15795949371005746
+          - --start-lambda=0.8460635942002347
+          - --end-lambda=0.7490913625693039
+          - --in-scaling=294.7193839807687
+          - --out-scaling=364.552099066772
+          - --in-offset=281.4186220835457
+          - --out-offset=279.93991915496105
+          - --random-fen-skipping=10
+          - --early-fen-skipping=28
         resume: previous_model
       trainer:
         owner: official-stockfish
@@ -127,19 +489,19 @@ testing:
   reference:
     code:
       owner: official-stockfish
-      sha: 64e8e1b247367018ebbce15f0d7cf5a56c7eaf56
+      sha: adfddd2c984fac5f2ac02d87575af821ec118fa8
   testing:
     code:
       owner: official-stockfish
-      sha: 64e8e1b247367018ebbce15f0d7cf5a56c7eaf56
+      sha: adfddd2c984fac5f2ac02d87575af821ec118fa8
   fastchess:
     code:
       owner: Disservin
-      sha: 7676d4961518a7a0156bcd200149acc8c921f977
+      sha: 66cac47f06dc1a09d3d1865cdbf560a7814f82ea
     options:
        tc: 10+0.1
        hash: 16
     sprt:
-       nElo_interval_midpoint: -30
-       nElo_interval_width: 3
-       max_rounds: 160000
+       nElo_interval_midpoint: -15
+       nElo_interval_width: 2
+       max_rounds: 100000


### PR DESCRIPTION
reconstructed pipeline for training SF large net.

based on / inspired by:
https://github.com/official-stockfish/Stockfish/commit/0716b845fdef8a20102b07eaec074b8da8162523 https://github.com/linrock/nnue-tools/blob/master/exp-sequences/3072-10stage-SFNNv9.yml

roughly on par with master net when accounting for the alleged 7 Elo of SPSA training.