### PR TITLE
no-pnm-active with corrected lr

### DIFF
--- a/threats.yaml
+++ b/threats.yaml
@@ -51,7 +51,7 @@ training:
         max_epochs: 800
         other_options:
           - --optimizer-name=rangerlite
-          - --no-pnm-active
+          - --pnm-momentum=0.0
           - --batch-size=65536
           - --features=Full_Threats+HalfKAv2_hm^
           - --l1=1024
@@ -71,7 +71,7 @@ training:
         resume: none
       trainer:
         owner: TonyCongqianWang
-        sha: d3da8cdb6212c5dee509bad0dcbc1b83ebb61008
+        sha: a56b297990707aed07cd481b02cee2956546afee
     - <repeat_last>:
         run:
           resume: previous_model

--- a/threats.yaml
+++ b/threats.yaml
@@ -50,11 +50,13 @@ training:
           - official-stockfish/master-binpacks/dfrc_n5000.binpack
         max_epochs: 800
         other_options:
+          - --optimizer-name=rangerlite
+          - --no-pnm-active
           - --batch-size=65536
           - --features=Full_Threats+HalfKAv2_hm^
           - --l1=1024
           - --l2=31
-          - --lr=4.375e-4
+          - --lr=1.9556e-4
           - --gamma=0.995
           - --start-lambda=1.0
           - --end-lambda=0.75
@@ -68,8 +70,8 @@ training:
         repetitions: 1
         resume: none
       trainer:
-        owner: official-stockfish
-        sha: 6a448afa7b75809b4e12cf6e2b259fac8230b22d
+        owner: TonyCongqianWang
+        sha: d3da8cdb6212c5dee509bad0dcbc1b83ebb61008
     - <repeat_last>:
         run:
           resume: previous_model
@@ -107,7 +109,7 @@ training:
             - linrock/test80-2024/test80-2024-01-jan-2tb7p.min-v2.v6.binpack
             - linrock/test80-2024/test80-2024-02-feb-2tb7p.min-v2.v6.binpack
           other_options:
-            - --lr=0.0010783148702050778
+            - --lr=4.82e-4
             - --gamma=0.994446435229841
             - --pow-exp=2.442037790427722
             - --qp-asymmetry=0.15795949371005746
@@ -121,6 +123,3 @@ training:
     - <repeat_last>:
     - <repeat_last>:
     - <repeat_last>:
-          other_options:
-            - --lr=0.00042301976890599417
-            - --gamma=0.9935974858411222


### PR DESCRIPTION
Trying no-pnm again but with adjusted lr based on geminis analysis