### PR TITLE
Passed pawns

### DIFF
--- a/threats.yaml
+++ b/threats.yaml
@@ -2,7 +2,7 @@ testing:
   fastchess:
     code:
       owner: Disservin
-      sha: adc3d025006f2efe7e014cde7dc46970f3bb7252
+      sha: 541aef889206882de4823cf5a676d53ac5171c6f
     options:
       hash: 16
       max_rounds: 80000

--- a/threats.yaml
+++ b/threats.yaml
@@ -14,13 +14,13 @@ testing:
     code:
       owner: official-stockfish
       sha: 5eeca7392ee90b7a43da69e647e3d596e42992fd
-      target: build
+      target: profile-build
   steps: all
   testing:
     code:
       owner: DanSamek
       sha: 2c0e23a53111a0f8a1dab9db99d249255e130d71
-      target: build
+      target: profile-build
 training:
   steps:
     - convert:

--- a/threats.yaml
+++ b/threats.yaml
@@ -13,13 +13,13 @@ testing:
   reference:
     code:
       owner: official-stockfish
-      sha: 5eeca7392ee90b7a43da69e647e3d596e42992fd
+      sha: bb4eb04a50244442f2925f6dad3b1b2fb1f82236
       target: profile-build
   steps: all
   testing:
     code:
       owner: DanSamek
-      sha: c6170bf09d411fe459c305f7558b16e76f6e765d
+      sha: 0fad71be0fd078c9fa86d0323bf1d6c87750b9fb
       target: profile-build
 training:
   steps:

--- a/threats.yaml
+++ b/threats.yaml
@@ -13,13 +13,13 @@ testing:
   reference:
     code:
       owner: official-stockfish
-      sha: d173a0655d04b95497eefb75b400baa3eff56f93
+      sha: 5eeca7392ee90b7a43da69e647e3d596e42992fd
       target: build
   steps: all
   testing:
     code:
-      owner: anematode
-      sha: e4680b619e265510becf4447104d10025b59761a
+      owner: DanSamek
+      sha: 2c0e23a53111a0f8a1dab9db99d249255e130d71
       target: build
 training:
   steps:
@@ -68,8 +68,8 @@ training:
         repetitions: 1
         resume: none
       trainer:
-        owner: anematode
-        sha: 5e43bc06759c8b15ca8b4244d69634a0b62750ac
+        owner: DanSamek
+        sha: 583ca992c365df6c99d9946968cf6ecddede0f81
     - <repeat_last>:
         run:
           resume: previous_model

--- a/threats.yaml
+++ b/threats.yaml
@@ -19,7 +19,7 @@ testing:
   testing:
     code:
       owner: DanSamek
-      sha: 2c0e23a53111a0f8a1dab9db99d249255e130d71
+      sha: c6170bf09d411fe459c305f7558b16e76f6e765d
       target: profile-build
 training:
   steps:


### PR DESCRIPTION
Add new TI inputs for passed pawns.
To avoid adding new features, we do a small index hack - same color pawn "attacks" itself reverse promo square.

And also as in king ring inputs, it would be great if someone who knows better TI reviewed the changes before the training run.
 
The code changes also contains: https://github.com/official-stockfish/Stockfish/pull/6701
It was necessary for NNUE updates debugging.

