### PR TITLE
safe git dir

### DIFF
--- a/nettest/train.py
+++ b/nettest/train.py
@@ -44,6 +44,13 @@ def ensure_trainer(trainer):
             )
 
             execute(
+                f"[attempt {attempt}] clone trainer",
+                ["git", "config", "--global", "safe.directory", str(temp_nnue_pytorch_dir)],
+                temp_nnue_pytorch_dir,
+                False,
+            )
+
+            execute(
                 f"[attempt {attempt}] checkout sha",
                 ["git", "checkout", "--detach", sha],
                 temp_nnue_pytorch_dir,


### PR DESCRIPTION
when I run this locally I get the following error, i'm not entirely sure what causes this but I think this change doesn't hurt

```
✅ [2026-04-14 18:33:22][[attempt 1] clone trainer] completed successfully.

➡️  [2026-04-14 18:33:22][[attempt 1] checkout sha] git checkout --detach a758c338befdbe0cf0e098c703130d979917ec19 (cwd=/workspace/scratch/packages/trainer/a758c338befdbe0cf0e098c703130d979917ec19_build_4232a28f-dd50-4543-8854-29bfe70dbdf5/nnue-pytorch)
-------------------------------------------------------------
fatal: detected dubious ownership in repository at '/workspace/scratch/packages/trainer/a758c338befdbe0cf0e098c703130d979917ec19_build_4232a28f-dd50-4543-8854-29bfe70dbdf5/nnue-pytorch'
To add an exception for this directory, call:

        git config --global --add safe.directory /workspace/scratch/packages/trainer/a758c338befdbe0cf0e098c703130d979917ec19_build_4232a28f-dd50-4543-8854-29bfe70dbdf5/nnue-pytorch
❌ [2026-04-14 18:33:22][[attempt 1] checkout sha] failed with exit code 128
⚠️ Attempt 1 failed:
🔁 Retrying after 30 seconds...
^CTraceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/workspace/nettest/nettest/execute_recipe.py", line 100, in <module>
    bestNet, nElo = execute(executor, recipe, environment)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/nettest/nettest/execute_recipe.py", line 30, in execute
    executor.submit(run_step, environment, **kwargs).result()
  File "/usr/lib/python3.12/concurrent/futures/_base.py", line 451, in result
    self._condition.wait(timeout)
  File "/usr/lib/python3.12/threading.py", line 355, in wait
    waiter.acquire()
KeyboardInterrupt
Exception ignored in: <function _ExecutorManagerThread.__init__.<locals>.weakref_cb at 0x7f0b45af9d00>
Traceback (most recent call last):
  File "/usr/lib/python3.12/concurrent/futures/process.py", line 310, in weakref_cb
AttributeError: 'NoneType' object has no attribute 'util'
```