### PR TITLE
update async copies

### DIFF
--- a/threats.yaml
+++ b/threats.yaml
@@ -68,8 +68,8 @@ training:
         repetitions: 1
         resume: none
       trainer:
-        owner: official-stockfish
-        sha: a4385220412aa66bff1b9fb6b76cebf38c4ff035
+        owner: Disservin
+        sha: 2ee375d3d6a65359b87d2b6ac41a26611394b559
     - <repeat_last>:
         run:
           resume: previous_model


### PR DESCRIPTION
now i'm not sure how much of an speedup this is here but locally I see the copy happen during the kernel execution, from an old nsys that you shared memory overhead was only 6.6% with one gpu, compared to my ~25%

as expected this uses more gpu ram, looks like 6.6gb (iirc) to about 10 gb