### PR TITLE
Pawn progress buckets

### DIFF
--- a/threats.yaml
+++ b/threats.yaml
@@ -13,7 +13,7 @@ testing:
   reference:
     code:
       owner: official-stockfish
-      sha: 5eeca7392ee90b7a43da69e647e3d596e42992fd
+      sha: b1fb50ae697265369d51c002603a621ffe8f9bfa
       target: profile-build
   steps: all
   testing:
@@ -69,7 +69,7 @@ training:
         resume: none
       trainer:
         owner: DanSamek
-        sha: f26944f95989bf310a6ba26423ea25ad84c58813
+        sha: 3f87176fdd3ab5ecf87b3bcbc98ead6dec69d040
     - <repeat_last>:
         run:
           resume: previous_model

--- a/threats.yaml
+++ b/threats.yaml
@@ -18,8 +18,8 @@ testing:
   steps: all
   testing:
     code:
-      owner: official-stockfish
-      sha: 5eeca7392ee90b7a43da69e647e3d596e42992fd
+      owner: DanSamek
+      sha: f0cfd6b276e162950fa1abe7daac94fe8e5cf218
       target: profile-build
 training:
   steps:
@@ -68,8 +68,8 @@ training:
         repetitions: 1
         resume: none
       trainer:
-        owner: official-stockfish
-        sha: a4385220412aa66bff1b9fb6b76cebf38c4ff035
+        owner: DanSamek
+        sha: f26944f95989bf310a6ba26423ea25ad84c58813
     - <repeat_last>:
         run:
           resume: previous_model

--- a/threats.yaml
+++ b/threats.yaml
@@ -13,13 +13,13 @@ testing:
   reference:
     code:
       owner: official-stockfish
-      sha: b1fb50ae697265369d51c002603a621ffe8f9bfa
+      sha: 1e333b341ca0aa0fe4809527d7cd7859d540e06b
       target: profile-build
   steps: all
   testing:
     code:
       owner: DanSamek
-      sha: fb9258c38877f99e20f1b99e4041a049deb840ad
+      sha: b5619f670e4e115e80172cb9a8b7f75551e96247
       target: profile-build
 training:
   steps:
@@ -69,7 +69,7 @@ training:
         resume: none
       trainer:
         owner: DanSamek
-        sha: 3f87176fdd3ab5ecf87b3bcbc98ead6dec69d040
+        sha: 7c70f9186c874e26a6a7beb3ec464235ebf03544
     - <repeat_last>:
         run:
           resume: previous_model

--- a/threats.yaml
+++ b/threats.yaml
@@ -20,7 +20,7 @@ testing:
     code:
       owner: DanSamek
       sha: b5619f670e4e115e80172cb9a8b7f75551e96247
-      target: profile-build
+      target: build
 training:
   steps:
     - convert:

--- a/threats.yaml
+++ b/threats.yaml
@@ -14,7 +14,7 @@ testing:
     code:
       owner: official-stockfish
       sha: 1e333b341ca0aa0fe4809527d7cd7859d540e06b
-      target: profile-build
+      target: build
   steps: all
   testing:
     code:

--- a/threats.yaml
+++ b/threats.yaml
@@ -19,7 +19,7 @@ testing:
   testing:
     code:
       owner: DanSamek
-      sha: f0cfd6b276e162950fa1abe7daac94fe8e5cf218
+      sha: fb9258c38877f99e20f1b99e4041a049deb840ad
       target: profile-build
 training:
   steps:


### PR DESCRIPTION
From discussion on the discord server -- try to add "2D" bucket indexing based on pawn progress and piece count. 
Currently is set to 3 * 8 [pawn progress, piece count]

I am not sure about python scripts, if its enough to change default values in the constructor (or somewhere in the config):
```
num_psqt_buckets=24,
num_ls_buckets=24
 ```