### PR TITLE
Improve testing

### DIFF
--- a/ci/cscs.yml
+++ b/ci/cscs.yml
@@ -29,7 +29,7 @@ generateSchedule:
   script:
     - cd /workspace/
     - ln -s $CI_PROJECT_DIR ./cidir
-    - python -u -m nettest.generate_pipeline --environment /workspace/nettest/environments/clariden.yaml nettest/${RECIPE:-testing} --output-file ./cidir/training_schedule.yaml --output-recipe-file ./cidir/training_recipe.yaml
+    - python -u -m nettest.generate_pipeline --environment /workspace/nettest/environments/clariden.yaml nettest/${RECIPE:-testing} ./cidir/training_schedule.yaml ./cidir/training_recipe.yaml
     - cat ./cidir/training_schedule.yaml
   variables:
     SLURM_JOB_NUM_NODES: 1

--- a/ci/cscs.yml
+++ b/ci/cscs.yml
@@ -29,7 +29,7 @@ generateSchedule:
   script:
     - cd /workspace/
     - ln -s $CI_PROJECT_DIR ./cidir
-    - python -u -m nettest.generate_pipeline --environment /workspace/nettest/environments/clariden.yaml nettest/${RECIPE:-testing} ./cidir/training_schedule.yaml
+    - python -u -m nettest.generate_pipeline --environment /workspace/nettest/environments/clariden.yaml nettest/${RECIPE:-testing} --output-file ./cidir/training_schedule.yaml --output-recipe-file ./cidir/training_recipe.yaml
     - cat ./cidir/training_schedule.yaml
   variables:
     SLURM_JOB_NUM_NODES: 1
@@ -39,7 +39,7 @@ generateSchedule:
     expire_in: 1 month
     paths:
       - training_schedule.yaml
-      - training_schedule.yaml.recipe.yaml
+      - training_recipe.yaml
 
 # run the training according to the previously generated schedule
 runTraining:

--- a/ci/cscs.yml
+++ b/ci/cscs.yml
@@ -39,6 +39,7 @@ generateSchedule:
     expire_in: 1 month
     paths:
       - training_schedule.yaml
+      - training_schedule.yaml.recipe.yaml
 
 # run the training according to the previously generated schedule
 runTraining:

--- a/nettest/execute_recipe.py
+++ b/nettest/execute_recipe.py
@@ -18,7 +18,7 @@ def batch_function(f, items):
 
 
 def execute(executor, recipe, environment):
-    _, schedule = executor.submit(parse_recipe, recipe, None).result()
+    _, schedule, _ = executor.submit(parse_recipe, recipe, None).result()
 
     print("submitting data update", flush=True)
     executor.submit(batch_function, run_data_update, schedule["data"]).result()

--- a/nettest/generate_pipeline.py
+++ b/nettest/generate_pipeline.py
@@ -384,6 +384,8 @@ if __name__ == "__main__":
     )
     parser.add_argument("output_file", help="Output path for pipeline [and recipe] YAML file[s]", nargs='+')
 
+    args = parser.parse_args()
+
     # 1. Resolve input paths and shared directory
     input_parts = [p.strip() for p in args.input_files.split(":")]
     first_input = Path(input_parts[0])

--- a/nettest/generate_pipeline.py
+++ b/nettest/generate_pipeline.py
@@ -383,6 +383,7 @@ if __name__ == "__main__":
         help="Input recipes (e.g., path/to/test1:test2) without .yaml suffix",
     )
     parser.add_argument("output_file", help="Output pipeline YAML file")
+    parser.add_argument("output_recipe_file", help="Output final recipe YAML file", required=False, default=None)
     args = parser.parse_args()
 
     # 1. Resolve input paths and shared directory
@@ -477,6 +478,7 @@ if __name__ == "__main__":
     with Path(args.output_file).open(mode="w", encoding="utf-8") as f:
         yaml.dump(final_ci_out, f, Dumper=MyDumper, default_flow_style=False, width=300)
 
-    with Path(f"{args.output_file}.recipe.yaml").open(mode="w", encoding="utf-8") as f:
-        yaml.dump(final_recipe, f, Dumper=MyDumper, default_flow_style=False, width=300)
+    if args.output_recipe_file is not None:
+        with Path(args.output_recipe_file).open(mode="w", encoding="utf-8") as f:
+            yaml.dump(final_recipe, f, Dumper=MyDumper, default_flow_style=False, width=300)
 

--- a/nettest/generate_pipeline.py
+++ b/nettest/generate_pipeline.py
@@ -302,6 +302,11 @@ def generate_testing_stage(
             job["script"] = ["cd /workspace/", "ln -s $CI_PROJECT_DIR ./cidir"]
             job["script"].append(task)
 
+            job["artifacts"] = {
+                "expire_in": "1 month",
+                "paths": [f"test_{test_config_sha}_result"],
+            }
+
             # Establish explicit DAG dependencies to bypass stage wait times
             needs = []
             if "ensureDataJob" in ci_yaml_out:

--- a/nettest/generate_pipeline.py
+++ b/nettest/generate_pipeline.py
@@ -382,9 +382,7 @@ if __name__ == "__main__":
         "input_files",
         help="Input recipes (e.g., path/to/test1:test2) without .yaml suffix",
     )
-    parser.add_argument("output_file", help="Output pipeline YAML file")
-    parser.add_argument("output_recipe_file", help="Output final recipe YAML file", required=False, default=None)
-    args = parser.parse_args()
+    parser.add_argument("output_file", help="Output path for pipeline [and recipe] YAML file[s]", nargs='+')
 
     # 1. Resolve input paths and shared directory
     input_parts = [p.strip() for p in args.input_files.split(":")]
@@ -475,10 +473,10 @@ if __name__ == "__main__":
         merged_ensure_job["script"].extend(sorted(list(merged_python_lines)))
         final_ci_out["ensureDataJob"] = merged_ensure_job
 
-    with Path(args.output_file).open(mode="w", encoding="utf-8") as f:
+    with Path(args.output_file[0]).open(mode="w", encoding="utf-8") as f:
         yaml.dump(final_ci_out, f, Dumper=MyDumper, default_flow_style=False, width=300)
 
-    if args.output_recipe_file is not None:
-        with Path(args.output_recipe_file).open(mode="w", encoding="utf-8") as f:
+    if len(args.output_file) > 1:
+        with Path(args.output_file[1]).open(mode="w", encoding="utf-8") as f:
             yaml.dump(final_recipe, f, Dumper=MyDumper, default_flow_style=False, width=300)
 

--- a/nettest/generate_pipeline.py
+++ b/nettest/generate_pipeline.py
@@ -372,7 +372,7 @@ def parse_recipe(recipe, environment):
     print("schedule information:")
     print(yaml.dump(schedule, Dumper=MyDumper, default_flow_style=False, width=300))
 
-    return ci_yaml_out, schedule
+    return ci_yaml_out, schedule, recipe
 
 
 if __name__ == "__main__":
@@ -409,7 +409,7 @@ if __name__ == "__main__":
         with open(recipe_path) as f:
             recipe = yaml.safe_load(f)
 
-        ci_out, schedule = parse_recipe(recipe, args.environment)
+        ci_out, schedule, final_recipe = parse_recipe(recipe, args.environment)
 
         # Merge unique includes
         for inc in ci_out.get("include", []):
@@ -476,3 +476,7 @@ if __name__ == "__main__":
 
     with Path(args.output_file).open(mode="w", encoding="utf-8") as f:
         yaml.dump(final_ci_out, f, Dumper=MyDumper, default_flow_style=False, width=300)
+
+    with Path(f"{args.output_file}.recipe.yaml").open(mode="w", encoding="utf-8") as f:
+        yaml.dump(final_recipe, f, Dumper=MyDumper, default_flow_style=False, width=300)
+

--- a/nettest/test.py
+++ b/nettest/test.py
@@ -274,7 +274,7 @@ def run_fastchess(
             f"{affinity}",
         ]
 
-    cmd += ["-rounds", f"{rounds}", "-games", "2", "-repeat", "-srand", "42"]
+    cmd += ["-rounds", f"{rounds}", "-games", "2", "-repeat", "-srand", "$RANDOM"]
     cmd += sprt_options
     cmd += ["-ratinginterval", "100"]
 
@@ -440,7 +440,7 @@ def run_test(environment, test_config_sha, testing_sha):
 
     run_cross_check_eval(environment, test, testing_sha, stockfish_testing)
 
-    return run_fastchess(
+    winning_net, nElo = run_fastchess(
         environment,
         test_config_sha,
         test,
@@ -449,6 +449,16 @@ def run_test(environment, test_config_sha, testing_sha):
         stockfish_reference,
         stockfish_testing,
     )
+
+    # store as an artifact for this run
+    artifact_dir = Path.cwd() / "cidir" / f"test_{test_config_sha}_result"
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    artifact_txt = artifact_dir / f"{testing_sha}_result.txt"
+    with open(artifact_txt, "w") as f:
+        f.write(f"Winning net: {winning_net}\n")
+        f.write(f"Elo: {nElo}\n")
+
+    return winning_net, nElo
 
 
 if __name__ == "__main__":

--- a/nettest/test.py
+++ b/nettest/test.py
@@ -8,6 +8,7 @@ import shutil
 import uuid
 import time
 import os
+import random
 
 
 def ensure_fastchess(fastchess):
@@ -274,7 +275,7 @@ def run_fastchess(
             f"{affinity}",
         ]
 
-    cmd += ["-rounds", f"{rounds}", "-games", "2", "-repeat", "-srand", "$RANDOM"]
+    cmd += ["-rounds", f"{rounds}", "-games", "2", "-repeat", "-srand", f"{random.randint(0, 10000)}"]
     cmd += sprt_options
     cmd += ["-ratinginterval", "100"]
 


### PR DESCRIPTION
Does a few small things that aim to improve automation:
* Adding the final recipe (expanded and with shas) to artifacts -- allows for debugging and also documentation
* Writes winning_net and nElo to a txt file and adds to step artifact for testing steps
* Uses random seed for opening order instead of fixed seed of 42 to de-correlate training step run results