### PR TITLE
remove featureTransformer biases

### DIFF
--- a/testing.yaml
+++ b/testing.yaml
@@ -29,8 +29,8 @@ common_run_options: &common_run_options
   pc-y4: 0.75
 
 trainer: &trainer
-  owner: official-stockfish
-  sha: e215624395d03ee3aeb9e7640c4d4570518b37ac
+  owner: ces42
+  sha: 86eac8166f2fed2a8bca72cec603d84dffa00730
 
 # --- Grouped Structure Anchors for Redundancy Reduction ---
 common_convert: &common_convert
@@ -44,7 +44,7 @@ common_step: &common_step
 
 official_code: &official_code
   owner: official-stockfish
-  sha: dd321af5dfc0789de07c4e5c64915073995eb818
+  sha: 133731f33166afcde7fb7a76c41e47c3cddcee8b
   target: profile-build
 # ----------------------------------------------------------
 
@@ -72,7 +72,10 @@ testing:
     code: *official_code
   steps: all
   testing:
-    code: *official_code
+    code:
+      owner: ces42
+      sha: 0e2ba507e5e5515516bc5829a60c1ef2ae534749
+      target: profile-build
 
 training:
   steps:

--- a/testing.yaml
+++ b/testing.yaml
@@ -45,7 +45,7 @@ common_step: &common_step
 official_code: &official_code
   owner: official-stockfish
   sha: 133731f33166afcde7fb7a76c41e47c3cddcee8b
-  target: profile-build
+  target: build
 # ----------------------------------------------------------
 
 testing:
@@ -75,7 +75,7 @@ testing:
     code:
       owner: ces42
       sha: 0e2ba507e5e5515516bc5829a60c1ef2ae534749
-      target: profile-build
+      target: build
 
 training:
   steps:

--- a/threats.yaml
+++ b/threats.yaml
@@ -99,8 +99,8 @@ advanced_stage_options: &advanced_stage_options
   end-lambda: 0.76
 
 trainer: &trainer
-  owner: official-stockfish
-  sha: 89d572575441c927947fdc8b98c41719c530d120
+  owner: ces42
+  sha: 051bbe74a49e33e167f90d3955e1b7dcfccd5584
 
 # --- Grouped Structure Anchors for Redundancy Reduction ---
 common_convert: &common_convert
@@ -124,7 +124,7 @@ common_run_checkpoint: &common_run_checkpoint
 official_code: &official_code
   owner: official-stockfish
   sha: b1053e60b7e0fe3187006c4d7f38dbd22eaff763
-  target: profile-build
+  target: build
 # ----------------------------------------------------------
 
 testing:
@@ -148,7 +148,10 @@ testing:
     code: *official_code
   steps: all
   testing:
-    code: *official_code
+    code:
+      owner: ces42
+      sha: 82cf860ac40981e2aa61e3ae4d3fc76e3647e268
+      target: build
 
 training:
   steps:


### PR DESCRIPTION
trainer and sf changes remove biases. This is on top of the latest commit instead of the PR of the last master net, but I assume that is right?