### PR TITLE
From scratch BT4 distill using selfplay (no T80 relabelling)

### DIFF
--- a/nettest/generate_pipeline.py
+++ b/nettest/generate_pipeline.py
@@ -173,6 +173,11 @@ def generate_ensure_data(recipe, ci_yaml_out, schedule):
 
     repos = defaultdict(list)
     for binpack in binpacks:
+        # Absolute paths point to local binpacks (e.g. on a mounted drive) that
+        # the trainer reads as-is; they are not hosted on huggingface, so skip
+        # them in the data-download step.
+        if Path(binpack).is_absolute():
+            continue
         owner, repo, filename = binpack.split("/", 2)
         repos[(owner, repo)].append(filename)
 

--- a/nettest/train.py
+++ b/nettest/train.py
@@ -149,11 +149,11 @@ def run_trainer(environment, current_sha, previous_sha, run, nnue_pytorch_dir):
     num_gpus = len([d for d in devices.split(",") if d.strip()])
     local_devices = "".join([f"{i}," for i in range(num_gpus)])
     nproc = max(1, num_gpus)
+    cpunodebind = environment.get("train", {}).get("cpunodebind", "0")
+    membind = environment.get("train", {}).get("membind", "0")
     if nproc > 1:
         cmd = ["torchrun", f"--nproc-per-node={nproc}", "ddp_launcher.py", "train.py"]
-    elif supports_numactl():
-        cpunodebind = environment["train"].get("cpunodebind", "0")
-        membind = environment["train"].get("membind", "0")
+    elif supports_numactl(cpunodebind, membind):
         cmd = ["numactl", f"--cpunodebind={cpunodebind}", f"--membind={membind}"]
         cmd += ["python", "-u", "train.py"]
     else:

--- a/nettest/utils.py
+++ b/nettest/utils.py
@@ -34,12 +34,19 @@ class MyDumper(yaml.Dumper):
         return super(MyDumper, self).increase_indent(flow, False)
 
 
-def supports_numactl() -> bool:
+def supports_numactl(cpunodebind="0", membind="0") -> bool:
     if not shutil.which("numactl"):
         return False
     try:
+        # numactl must be present AND actually able to apply the requested binding.
+        # In some containers `numactl --hardware` succeeds but `--membind` /
+        # `--cpunodebind` fail at runtime ("setting membind: Invalid argument"),
+        # e.g. when the memory cgroup doesn't expose NUMA nodes. Probe the real
+        # binding so we cleanly fall back to plain python when it can't bind.
         result = subprocess.run(
-            ["numactl", "--hardware"], capture_output=True, timeout=5
+            ["numactl", f"--cpunodebind={cpunodebind}", f"--membind={membind}", "true"],
+            capture_output=True,
+            timeout=5,
         )
         return result.returncode == 0
     except Exception:

--- a/threats.yaml
+++ b/threats.yaml
@@ -2,10 +2,10 @@
 # instead of the huggingface-hosted stockfish binpacks. Absolute paths are used
 # as-is by the trainer and are skipped by the huggingface download step.
 stage_one_binpacks: &stage_one_binpacks
-  - /mnt/Array55T_remote/viren/interleaved-new-policy.binpack
+  - /mnt/Array55T_remote/viren/interleaved-new-policy-compact.binpack
 
 stage_two_plus_binpacks: &stage_two_plus_binpacks
-  - /mnt/Array55T_remote/viren/interleaved-new-policy.binpack
+  - /mnt/Array55T_remote/viren/interleaved-new-policy-compact.binpack
 
 model_config: &model_config
   features: Full_Threats+HalfKAv2_hm^
@@ -29,7 +29,11 @@ common_run_options: &common_run_options
   batch-size: 65536
   <<: *model_config
   factorized-weight-decay: 0.001
-  random-fen-skipping: 10
+  # Decorrelation is now done by the in-loader block shuffle (shuffle-buffer-gib)
+  # instead of random-fen-skipping, so every position is used (no data dropped).
+  random-fen-skipping: 0
+  shuffle-buffer-gib: 120.0   # total host RAM for the montyformat shuffle buffer (train stream only)
+  grad-clip-percentile: 99.0   # adaptive grad-norm clip: clips the ~1% largest-norm steps (NaN safety net)
   early-fen-skipping: -18   # no hard opening cutoff
   soft-early-fen_skipping: 14   # soft early-ply ramp shifted 18 plies earlier (orig 32 - 18; ply-x* below also -18)
   pc-y0: -0.20
@@ -82,7 +86,7 @@ advanced_stage_options: &advanced_stage_options
 # sha below to the pushed commit. See MONTYFORMAT.md for details.
 trainer: &trainer
   owner: Viren6                          # github.com/Viren6/nnue-pytorch (with montyformat reader)
-  sha: 0951fbd686ae1b7630d6eba2537238dd19259d40   # montyformat reader + filters + parallel decode
+  sha: ffba5cf87ffc147714fa46ab3decea387ff52e01   # + adaptive grad-norm clipping (NaN safety net)
 
 reference_code: &reference_code
   owner: official-stockfish
@@ -148,7 +152,7 @@ training:
           <<: [*common_run_options, *warmups_stage_options]
           one-cycle-steps: 381500
           swa-start-epoch: 240
-          lr: "1.5e-3"
+          lr: "1.0e-3"
         repetitions: 1
         resume: none
 
@@ -160,7 +164,7 @@ training:
         other_options:
           <<: [*common_run_options, *advanced_stage_options]
           one-cycle-steps: 1373400
-          lr: "1.3e-3"
+          lr: "0.8e-3"
           swa-start-epoch: 900
 
     # Stage 3
@@ -172,4 +176,4 @@ training:
         other_options:
           <<: [*common_run_options, *advanced_stage_options]
           one-cycle-steps: 4578000
-          lr: "0.65e-3"
+          lr: "0.4e-3"

--- a/threats.yaml
+++ b/threats.yaml
@@ -33,7 +33,7 @@ common_run_options: &common_run_options
   # Decorrelation is now done by the in-loader block shuffle (shuffle-buffer-gib)
   # instead of random-fen-skipping, so every position is used (no data dropped).
   random-fen-skipping: 0
-  shuffle-buffer-gib: 120.0   # total host RAM for the montyformat shuffle buffer (train stream only)
+  shuffle-buffer-gib: 80.0   # total host RAM for the montyformat shuffle buffer (train stream only; per DDP rank)
   grad-clip-percentile: 99.0   # adaptive grad-norm clip: clips the ~1% largest-norm steps (NaN safety net)
   early-fen-skipping: -18   # no hard opening cutoff
   soft-early-fen_skipping: 14   # soft early-ply ramp shifted 18 plies earlier (orig 32 - 18; ply-x* below also -18)

--- a/threats.yaml
+++ b/threats.yaml
@@ -1,47 +1,11 @@
+# Training now reads a single local interleaved binpack on the mounted drive
+# instead of the huggingface-hosted stockfish binpacks. Absolute paths are used
+# as-is by the trainer and are skipped by the huggingface download step.
 stage_one_binpacks: &stage_one_binpacks
-  - vondele/from_kaggle_2/T60T70wIsRightFarseerT60T74T75T76.split_0.binpack
-  - vondele/from_kaggle_2/T60T70wIsRightFarseerT60T74T75T76.split_1.binpack
-  - vondele/from_kaggle_2/T60T70wIsRightFarseerT60T74T75T76.split_2.binpack
-  - vondele/from_kaggle_2/T60T70wIsRightFarseerT60T74T75T76.split_3.binpack
-  - vondele/from_kaggle_2/T60T70wIsRightFarseerT60T74T75T76.split_4.binpack
-  - official-stockfish/master-binpacks/nodes5000pv2_UHO.binpack
-  - official-stockfish/master-binpacks/wrongIsRight_nodes5000pv2.binpack
-  - official-stockfish/master-binpacks/multinet_pv-2_diff-100_nodes-5000.binpack
-  - official-stockfish/master-binpacks/dfrc_n5000.binpack
+  - /mnt/Array55T_remote/viren/interleaved-new-policy.binpack
 
 stage_two_plus_binpacks: &stage_two_plus_binpacks
-  - vondele/from_kaggle_1/leela96-filt-v2.min.split_0.binpack
-  - vondele/from_kaggle_1/leela96-filt-v2.min.split_1.binpack
-  - vondele/from_kaggle_1/leela96-filt-v2.min.split_2.binpack
-  - vondele/from_kaggle_1/leela96-filt-v2.min.split_3.binpack
-  - vondele/from_kaggle_1/leela96-filt-v2.min.split_4.binpack
-  - linrock/test60/test60-2021-11-nov-12tb7p.min-v2.binpack
-  - linrock/test60/test60-2021-12-dec-12tb7p.min-v2.binpack
-  - linrock/test77/test77-2021-12-dec-16tb7p.v6-dd.min.binpack
-  - linrock/test78/test78-2022-01-to-05-jantomay-16tb7p.v6-dd.min.binpack
-  - linrock/test79/test79-2022-04-apr-16tb7p.v6-dd.min.binpack
-  - linrock/test79/test79-2022-05-may-16tb7p.v6-dd.min.binpack
-  - linrock/test78/test78-2022-06-to-09-juntosep-16tb7p.v6-dd.min.binpack
-  - linrock/test80-2022/test80-2022-06-jun-16tb7p.v6-dd.min.binpack
-  - linrock/test80-2022/test80-2022-07-jul-16tb7p.v6-dd.min.binpack
-  - linrock/test80-2022/test80-2022-08-aug-16tb7p.v6-dd.min.binpack
-  - linrock/test80-2022/test80-2022-09-sep-16tb7p.v6-dd.min.binpack
-  - linrock/test80-2022/test80-2022-10-oct-16tb7p.v6-dd.binpack
-  - linrock/test80-2022/test80-2022-11-nov-16tb7p.v6-dd.min.binpack
-  - linrock/test80-2023/test80-2023-01-jan-16tb7p.v6-sk20.min.binpack
-  - linrock/test80-2023/test80-2023-02-feb-16tb7p.v6-dd.min.binpack
-  - linrock/test80-2023/test80-2023-03-mar-2tb7p.v6-sk16.min.binpack
-  - linrock/test80-2023/test80-2023-04-apr-2tb7p.v6-sk16.min.binpack
-  - linrock/test80-2023/test80-2023-05-may-2tb7p.v6.min.binpack
-  - linrock/test80-2023/test80-2023-06-jun-2tb7p.min-v2.v6.binpack
-  - linrock/test80-2023/test80-2023-07-jul-2tb7p.min-v2.v6.binpack
-  - linrock/test80-2023/test80-2023-08-aug-2tb7p.v6.min.binpack
-  - linrock/test80-2023/test80-2023-09-sep-2tb7p.min-v2.v6.binpack
-  - linrock/test80-2023/test80-2023-10-oct-2tb7p.min-v2.v6.binpack
-  - linrock/test80-2023/test80-2023-11-nov-2tb7p.min-v2.v6.binpack
-  - linrock/test80-2023/test80-2023-12-dec-2tb7p.min-v2.v6.binpack
-  - linrock/test80-2024/test80-2024-01-jan-2tb7p.min-v2.v6.binpack
-  - linrock/test80-2024/test80-2024-02-feb-2tb7p.min-v2.v6.binpack
+  - /mnt/Array55T_remote/viren/interleaved-new-policy.binpack
 
 model_config: &model_config
   features: Full_Threats+HalfKAv2_hm^
@@ -111,9 +75,14 @@ advanced_stage_options: &advanced_stage_options
   start-lambda: 0.74
   end-lambda: 0.74
 
+# Trainer must include the montyformat (policy) data-loader changes so the
+# interleaved-new-policy.binpack (Monty format, not Stockfish binpack) can be
+# read. Those changes are applied locally at ~/sf_experiments/nnue-pytorch
+# (branch monty-bt4-distill-data); commit + push them to the fork, then set the
+# sha below to the pushed commit. See MONTYFORMAT.md for details.
 trainer: &trainer
-  owner: official-stockfish
-  sha: 89d572575441c927947fdc8b98c41719c530d120
+  owner: Viren6                          # github.com/Viren6/nnue-pytorch (with montyformat reader)
+  sha: 58473206cf0092c21ccdc1af5f3935bd74be5762   # montyformat reader commit
 
 reference_code: &reference_code
   owner: official-stockfish

--- a/threats.yaml
+++ b/threats.yaml
@@ -1,11 +1,12 @@
-# Training now reads a single local interleaved binpack on the mounted drive
-# instead of the huggingface-hosted stockfish binpacks. Absolute paths are used
-# as-is by the trainer and are skipped by the huggingface download step.
+# Training reads the compact 16-bit-Gini binpack hosted on huggingface
+# (Viren6/MontySFExperiment). The ensureData job snapshot_downloads it to
+# data/<owner>/<repo>/<file> and the trainer reads it from there (owner/repo/file
+# form, NOT an absolute path -> it is fetched from HF, not read from a mount).
 stage_one_binpacks: &stage_one_binpacks
-  - /mnt/Array55T_remote/viren/interleaved-new-policy-compact.binpack
+  - Viren6/MontySFExperiment/interleaved-new-policy-compact.binpack
 
 stage_two_plus_binpacks: &stage_two_plus_binpacks
-  - /mnt/Array55T_remote/viren/interleaved-new-policy-compact.binpack
+  - Viren6/MontySFExperiment/interleaved-new-policy-compact.binpack
 
 model_config: &model_config
   features: Full_Threats+HalfKAv2_hm^

--- a/threats.yaml
+++ b/threats.yaml
@@ -87,7 +87,7 @@ advanced_stage_options: &advanced_stage_options
 # sha below to the pushed commit. See MONTYFORMAT.md for details.
 trainer: &trainer
   owner: Viren6                          # github.com/Viren6/nnue-pytorch (with montyformat reader)
-  sha: ffba5cf87ffc147714fa46ab3decea387ff52e01   # + adaptive grad-norm clipping (NaN safety net)
+  sha: c3a3486a7459dc1d4dd9eebbbbfc1637885e3e1b   # + raised prefetch (3h) & DDP collective timeouts for large buffers
 
 reference_code: &reference_code
   owner: official-stockfish

--- a/threats.yaml
+++ b/threats.yaml
@@ -153,7 +153,7 @@ training:
           <<: [*common_run_options, *warmups_stage_options]
           one-cycle-steps: 381500
           swa-start-epoch: 240
-          lr: "1.0e-3"
+          lr: "5.0e-4"
         repetitions: 1
         resume: none
 
@@ -165,7 +165,7 @@ training:
         other_options:
           <<: [*common_run_options, *advanced_stage_options]
           one-cycle-steps: 1373400
-          lr: "0.8e-3"
+          lr: "2.5e-4"
           swa-start-epoch: 900
 
     # Stage 3
@@ -177,4 +177,4 @@ training:
         other_options:
           <<: [*common_run_options, *advanced_stage_options]
           one-cycle-steps: 4578000
-          lr: "0.4e-3"
+          lr: "1.25e-4"

--- a/threats.yaml
+++ b/threats.yaml
@@ -82,7 +82,7 @@ advanced_stage_options: &advanced_stage_options
 # sha below to the pushed commit. See MONTYFORMAT.md for details.
 trainer: &trainer
   owner: Viren6                          # github.com/Viren6/nnue-pytorch (with montyformat reader)
-  sha: 58473206cf0092c21ccdc1af5f3935bd74be5762   # montyformat reader commit
+  sha: f63ea5d3ed54695b159c2dad8fcb2a7e5d48ecfb   # montyformat reader + Gini/capture/check filter
 
 reference_code: &reference_code
   owner: official-stockfish

--- a/threats.yaml
+++ b/threats.yaml
@@ -30,8 +30,8 @@ common_run_options: &common_run_options
   <<: *model_config
   factorized-weight-decay: 0.001
   random-fen-skipping: 10
-  early-fen-skipping: 18
-  soft-early-fen_skipping: 32
+  early-fen-skipping: -18   # no hard opening cutoff
+  soft-early-fen_skipping: 14   # soft early-ply ramp shifted 18 plies earlier (orig 32 - 18; ply-x* below also -18)
   pc-y0: -0.20
   pc-y1: 0.45
   pc-y2: 1.0
@@ -39,27 +39,27 @@ common_run_options: &common_run_options
   pc-y4: 0.75
 
 warmups_stage_options: &warmups_stage_options
-  ply-x1: 0.0
+  ply-x1: -18.0
   ply-y1: 0.01
-  ply-x2: 14.0
+  ply-x2: -4.0
   ply-y2: 0.20
-  ply-x3: 18.5
+  ply-x3: 0.5
   ply-y3: 0.50
-  ply-x4: 29.5
+  ply-x4: 11.5
   ply-y4: 0.80
   one-cycle-warmup-pct: 0.25
   one-cycle-final-div: "3e1"
   start-lambda: 1.0
-  end-lambda: 0.75
+  end-lambda: 1.0   # score-only (lambda=1 => target is purely the search score, no game result)
 
 advanced_stage_options: &advanced_stage_options
-  ply-x1: 0.00
+  ply-x1: -18.0
   ply-y1: 0.025
-  ply-x2: 22.0
+  ply-x2: 4.0
   ply-y2: 0.05
-  ply-x3: 25.5
+  ply-x3: 7.5
   ply-y3: 0.20
-  ply-x4: 29.5
+  ply-x4: 11.5
   ply-y4: 0.80
   pow-exp: 2.435
   qp-asymmetry: 0.23
@@ -69,11 +69,11 @@ advanced_stage_options: &advanced_stage_options
   out-offset: 300.0
   one-cycle-warmup-pct: 0.033
   one-cycle-final-div: "2e3"
-  jitter-lambda-sample: 0.0034
-  jitter-lambda-batch: 0.0062
+  jitter-lambda-sample: 0.0   # disabled: with lambda=1 the clamp would only pull it DOWN, reintroducing game result
+  jitter-lambda-batch: 0.0
   jitter-decay-lambda-batch: 0.999
-  start-lambda: 0.74
-  end-lambda: 0.74
+  start-lambda: 1.0   # score-only (lambda=1 => target is purely the search score, no game result)
+  end-lambda: 1.0
 
 # Trainer must include the montyformat (policy) data-loader changes so the
 # interleaved-new-policy.binpack (Monty format, not Stockfish binpack) can be

--- a/threats.yaml
+++ b/threats.yaml
@@ -82,7 +82,7 @@ advanced_stage_options: &advanced_stage_options
 # sha below to the pushed commit. See MONTYFORMAT.md for details.
 trainer: &trainer
   owner: Viren6                          # github.com/Viren6/nnue-pytorch (with montyformat reader)
-  sha: f63ea5d3ed54695b159c2dad8fcb2a7e5d48ecfb   # montyformat reader + Gini/capture/check filter
+  sha: 0951fbd686ae1b7630d6eba2537238dd19259d40   # montyformat reader + filters + parallel decode
 
 reference_code: &reference_code
   owner: official-stockfish


### PR DESCRIPTION
Note:
Data is still uploading to hugging face, ETA 8pm UTC.
Requires 128GB of RAM. This is because the data format is less compact, so with random skipping it becomes disk bound. Therefore, a 120GB shufflebuffer is used instead, which allows 287M positions to be shuffled together at once.

Total number of positions in data: ~40B total / ~18B filtered

The sharpness of the policy distribution is used as a filter as well as filtering all captures and checks