### PR TITLE
add hf_xet

### DIFF
--- a/ci/docker/Dockerfile.AMD
+++ b/ci/docker/Dockerfile.AMD
@@ -25,7 +25,7 @@ RUN pip install --no-cache-dir  nevergrad
 RUN pip install --no-cache-dir "firecrest-executor>=0.3.1"
 
 # enabler for hf downloads
-RUN pip install --no-cache-dir huggingface_hub zstandard
+RUN pip install --no-cache-dir huggingface_hub zstandard hf_xet
 
 # copy the current nettest sources to have them around
 COPY . /workspace/nettest/

--- a/ci/docker/Dockerfile.NVIDIA
+++ b/ci/docker/Dockerfile.NVIDIA
@@ -24,7 +24,7 @@ RUN pip install --no-cache-dir  nevergrad
 RUN pip install --no-cache-dir "firecrest-executor>=0.3.1"
 
 # enabler for hf downloads
-RUN pip install huggingface_hub zstandard
+RUN pip install huggingface_hub zstandard hf_xet
 
 # for cdbdirect
 RUN pip install pybind11


### PR DESCRIPTION
Got the following error when trying to run the relable all recipe
```
Error during repository update: The file is too large to be downloaded using the regular download method.  Install `hf_xet` with `pip install hf_xet` for xet-powered downloads.
```