### PR TITLE
add ablation recipes for testing

### DIFF
--- a/threats_qp.yaml
+++ b/threats_qp.yaml
@@ -1,18 +1,79 @@
-training_binpacks: &training_binpacks
+pretraining_binpacks_lq: &pretraining_binpacks_lq
+  - vondele/from_kaggle_1/leela96-filt-v2.min.split_0.binpack
+  - vondele/from_kaggle_1/leela96-filt-v2.min.split_1.binpack
+  - vondele/from_kaggle_1/leela96-filt-v2.min.split_2.binpack
+  - vondele/from_kaggle_1/leela96-filt-v2.min.split_3.binpack
+  - vondele/from_kaggle_1/leela96-filt-v2.min.split_4.binpack
+  - vondele/from_kaggle_2/T60T70wIsRightFarseerT60T74T75T76.split_0.binpack
+  - vondele/from_kaggle_2/T60T70wIsRightFarseerT60T74T75T76.split_1.binpack
+  - vondele/from_kaggle_2/T60T70wIsRightFarseerT60T74T75T76.split_2.binpack
+  - vondele/from_kaggle_2/T60T70wIsRightFarseerT60T74T75T76.split_3.binpack
+  - vondele/from_kaggle_2/T60T70wIsRightFarseerT60T74T75T76.split_4.binpack
   - vondele/from_kaggle_2_relabel/T60T70wIsRightFarseerT60T74T75T76.split_0.relabel-BT4-tf13tune.binpack
   - vondele/from_kaggle_2_relabel/T60T70wIsRightFarseerT60T74T75T76.split_1.relabel-BT4-tf13tune.binpack
   - vondele/from_kaggle_2_relabel/T60T70wIsRightFarseerT60T74T75T76.split_2.relabel-BT4-tf13tune.binpack
   - vondele/from_kaggle_2_relabel/T60T70wIsRightFarseerT60T74T75T76.split_3.relabel-BT4-tf13tune.binpack
   - vondele/from_kaggle_2_relabel/T60T70wIsRightFarseerT60T74T75T76.split_4.relabel-BT4-tf13tune.binpack
   - vondele/master-binpacks_relabel/nodes5000pv2_UHO.relabel-BT4-tf13tune.binpack
-  - vondele/master-binpacks_relabel/wrongIsRight_nodes5000pv2.relabel-BT4-tf13tune.binpack
+  - anematode/bt4-relabel/wrongIsRight_nodes5000pv2-rescored.binpack
   - vondele/master-binpacks_relabel/multinet_pv-2_diff-100_nodes-5000.relabel-BT4-tf13tune.binpack
   - vondele/master-binpacks_relabel/dfrc_n5000.relabel-BT4-tf13tune.binpack
-  - vondele/from_kaggle_1_relabel/leela96-filt-v2.min.split_0.relabel-BT4-tf13tune.binpack
-  - vondele/from_kaggle_1_relabel/leela96-filt-v2.min.split_1.relabel-BT4-tf13tune.binpack
-  - vondele/from_kaggle_1_relabel/leela96-filt-v2.min.split_2.relabel-BT4-tf13tune.binpack
-  - vondele/from_kaggle_1_relabel/leela96-filt-v2.min.split_3.relabel-BT4-tf13tune.binpack
-  - vondele/from_kaggle_1_relabel/leela96-filt-v2.min.split_4.relabel-BT4-tf13tune.binpack
+  - vondele/rescored/tb5dtm.binpack
+
+pretraining_binpacks_hq: &pretraining_binpacks_hq
+  - linrock/test60/test60-2021-11-nov-12tb7p.min-v2.binpack
+  - linrock/test60/test60-2021-12-dec-12tb7p.min-v2.binpack
+  - linrock/test77/test77-2021-12-dec-16tb7p.v6-dd.min.binpack
+  - linrock/test78/test78-2022-01-to-05-jantomay-16tb7p.v6-dd.min.binpack
+  - linrock/test79/test79-2022-04-apr-16tb7p.v6-dd.min.binpack
+  - linrock/test79/test79-2022-05-may-16tb7p.v6-dd.min.binpack
+  - linrock/test78/test78-2022-06-to-09-juntosep-16tb7p.v6-dd.min.binpack
+  - linrock/test80-2022/test80-2022-06-jun-16tb7p.v6-dd.min.binpack
+  - linrock/test80-2022/test80-2022-07-jul-16tb7p.v6-dd.min.binpack
+  - linrock/test80-2022/test80-2022-08-aug-16tb7p.v6-dd.min.binpack
+  - linrock/test80-2022/test80-2022-09-sep-16tb7p.v6-dd.min.binpack
+  - linrock/test80-2022/test80-2022-10-oct-16tb7p.v6-dd.binpack
+  - linrock/test80-2022/test80-2022-11-nov-16tb7p.v6-dd.min.binpack
+  - linrock/test80-2023/test80-2023-01-jan-16tb7p.v6-sk20.min.binpack
+  - linrock/test80-2023/test80-2023-02-feb-16tb7p.v6-dd.min.binpack
+  - linrock/test80-2023/test80-2023-03-mar-2tb7p.v6-sk16.min.binpack
+  - linrock/test80-2023/test80-2023-04-apr-2tb7p.v6-sk16.min.binpack
+  - linrock/test80-2023/test80-2023-05-may-2tb7p.v6.min.binpack
+  - linrock/test80-2023/test80-2023-06-jun-2tb7p.min-v2.v6.binpack
+  - linrock/test80-2023/test80-2023-07-jul-2tb7p.min-v2.v6.binpack
+  - linrock/test80-2023/test80-2023-08-aug-2tb7p.v6.min.binpack
+  - linrock/test80-2023/test80-2023-09-sep-2tb7p.min-v2.v6.binpack
+  - linrock/test80-2023/test80-2023-10-oct-2tb7p.min-v2.v6.binpack
+  - linrock/test80-2023/test80-2023-11-nov-2tb7p.min-v2.v6.binpack
+  - linrock/test80-2023/test80-2023-12-dec-2tb7p.min-v2.v6.binpack
+  - linrock/test80-2024/test80-2024-01-jan-2tb7p.min-v2.v6.binpack
+  - linrock/test80-2024/test80-2024-02-feb-2tb7p.min-v2.v6.binpack
+  - linrock/test80-2024/test80-2024-03-mar-2tb7p.min-v2.v6.binpack
+  - linrock/test80-2024/test80-2024-04-apr-2tb7p.min-v2.v6.binpack
+  - linrock/test80-2024/test80-2024-05-may-2tb7p.min-v2.v6.binpack
+  - linrock/test80-2024/test80-2024-06-jun-2tb7p.min-v2.v6.binpack
+  - vondele/from_kaggle_2_relabel/T60T70wIsRightFarseerT60T74T75T76.split_0.relabel-BT4-tf13tune.binpack
+  - vondele/from_kaggle_2_relabel/T60T70wIsRightFarseerT60T74T75T76.split_1.relabel-BT4-tf13tune.binpack
+  - vondele/from_kaggle_2_relabel/T60T70wIsRightFarseerT60T74T75T76.split_2.relabel-BT4-tf13tune.binpack
+  - vondele/from_kaggle_2_relabel/T60T70wIsRightFarseerT60T74T75T76.split_3.relabel-BT4-tf13tune.binpack
+  - vondele/from_kaggle_2_relabel/T60T70wIsRightFarseerT60T74T75T76.split_4.relabel-BT4-tf13tune.binpack
+  - vondele/master-binpacks_relabel/nodes5000pv2_UHO.relabel-BT4-tf13tune.binpack
+  - anematode/bt4-relabel/wrongIsRight_nodes5000pv2-rescored.binpack
+  - vondele/master-binpacks_relabel/multinet_pv-2_diff-100_nodes-5000.relabel-BT4-tf13tune.binpack
+  - vondele/master-binpacks_relabel/dfrc_n5000.relabel-BT4-tf13tune.binpack
+  - vondele/rescored/tb5dtm.binpack
+
+fine_tuning_binpacks_lq: &fine_tuning_binpacks_lq
+  - vondele/from_kaggle_2_relabel/T60T70wIsRightFarseerT60T74T75T76.split_0.relabel-BT4-tf13tune.binpack
+  - vondele/from_kaggle_2_relabel/T60T70wIsRightFarseerT60T74T75T76.split_1.relabel-BT4-tf13tune.binpack
+  - vondele/from_kaggle_2_relabel/T60T70wIsRightFarseerT60T74T75T76.split_2.relabel-BT4-tf13tune.binpack
+  - vondele/from_kaggle_2_relabel/T60T70wIsRightFarseerT60T74T75T76.split_3.relabel-BT4-tf13tune.binpack
+  - vondele/from_kaggle_2_relabel/T60T70wIsRightFarseerT60T74T75T76.split_4.relabel-BT4-tf13tune.binpack
+  - vondele/master-binpacks_relabel/nodes5000pv2_UHO.relabel-BT4-tf13tune.binpack
+  - anematode/bt4-relabel/wrongIsRight_nodes5000pv2-rescored.binpack
+  - vondele/master-binpacks_relabel/multinet_pv-2_diff-100_nodes-5000.relabel-BT4-tf13tune.binpack
+  - vondele/master-binpacks_relabel/dfrc_n5000.relabel-BT4-tf13tune.binpack
+  - vondele/rescored/tb5dtm.binpack
   - vondele/linrock_relabel_1/test60-2021-11-nov-12tb7p.min-v2.relabel-BT4-tf13tune.binpack
   - vondele/linrock_relabel_1/test60-2021-12-dec-12tb7p.min-v2.relabel-BT4-tf13tune.binpack
   - vondele/linrock_relabel_1/test77-2021-12-dec-16tb7p.v6-dd.min.relabel-BT4-tf13tune.binpack
@@ -99,7 +160,7 @@ advanced_stage_options: &advanced_stage_options
   w1: 3.3553547771220007
   w2: 0.7006821612968052
   pow-exp: 2.4340402395048404
-  qp-asymmetry: 0.22866886710086187
+  qp-asymmetry: 0.15
   in-scaling: 295.6539508488627
   out-scaling: 379.98724077106635
   in-offset: 285.2706341467852
@@ -157,7 +218,7 @@ testing:
       sha: b9008d08b9f375ef7810dc55da6ff223a3992cc2
     options:
       hash: 16
-      max_rounds: 30000
+      max_rounds: 100
       tc: 10+0.1
   reference:
     code: *reference_code
@@ -171,7 +232,7 @@ training:
     # Stage 1
     - <<: *common_step
       run:
-        binpacks: *training_binpacks
+        binpacks: *pretraining_binpacks_lq
         max_epochs: 500
         other_options:
           <<: [*common_run_options, *warmups_stage_options]
@@ -185,7 +246,7 @@ training:
     - <<: *common_step
       run:
         <<: *common_run_resume_model
-        binpacks: *training_binpacks
+        binpacks: *pretraining_binpacks_lq
         max_epochs: 2000
         other_options:
           <<: [*common_run_options, *advanced_stage_options]
@@ -196,7 +257,7 @@ training:
     - <<: *common_step
       run:
         <<: *common_run_resume_ckpt
-        binpacks: *training_binpacks
+        binpacks: *pretraining_binpacks_hq
         max_epochs: 3600
         other_options:
           <<: [*common_run_options, *advanced_stage_options]
@@ -208,7 +269,7 @@ training:
       trainer: *trainer
       run:
         <<: *common_run_resume_ckpt
-        binpacks: *training_binpacks
+        binpacks: *fine_tuning_binpacks_lq
         max_epochs: 3900
         other_options:
           <<: [*common_run_options, *advanced_stage_options]

--- a/threats_w.yaml
+++ b/threats_w.yaml
@@ -1,0 +1,281 @@
+pretraining_binpacks_lq: &pretraining_binpacks_lq
+  - vondele/from_kaggle_1/leela96-filt-v2.min.split_0.binpack
+  - vondele/from_kaggle_1/leela96-filt-v2.min.split_1.binpack
+  - vondele/from_kaggle_1/leela96-filt-v2.min.split_2.binpack
+  - vondele/from_kaggle_1/leela96-filt-v2.min.split_3.binpack
+  - vondele/from_kaggle_1/leela96-filt-v2.min.split_4.binpack
+  - vondele/from_kaggle_2/T60T70wIsRightFarseerT60T74T75T76.split_0.binpack
+  - vondele/from_kaggle_2/T60T70wIsRightFarseerT60T74T75T76.split_1.binpack
+  - vondele/from_kaggle_2/T60T70wIsRightFarseerT60T74T75T76.split_2.binpack
+  - vondele/from_kaggle_2/T60T70wIsRightFarseerT60T74T75T76.split_3.binpack
+  - vondele/from_kaggle_2/T60T70wIsRightFarseerT60T74T75T76.split_4.binpack
+  - vondele/from_kaggle_2_relabel/T60T70wIsRightFarseerT60T74T75T76.split_0.relabel-BT4-tf13tune.binpack
+  - vondele/from_kaggle_2_relabel/T60T70wIsRightFarseerT60T74T75T76.split_1.relabel-BT4-tf13tune.binpack
+  - vondele/from_kaggle_2_relabel/T60T70wIsRightFarseerT60T74T75T76.split_2.relabel-BT4-tf13tune.binpack
+  - vondele/from_kaggle_2_relabel/T60T70wIsRightFarseerT60T74T75T76.split_3.relabel-BT4-tf13tune.binpack
+  - vondele/from_kaggle_2_relabel/T60T70wIsRightFarseerT60T74T75T76.split_4.relabel-BT4-tf13tune.binpack
+  - vondele/master-binpacks_relabel/nodes5000pv2_UHO.relabel-BT4-tf13tune.binpack
+  - anematode/bt4-relabel/wrongIsRight_nodes5000pv2-rescored.binpack
+  - vondele/master-binpacks_relabel/multinet_pv-2_diff-100_nodes-5000.relabel-BT4-tf13tune.binpack
+  - vondele/master-binpacks_relabel/dfrc_n5000.relabel-BT4-tf13tune.binpack
+  - vondele/rescored/tb5dtm.binpack
+
+pretraining_binpacks_hq: &pretraining_binpacks_hq
+  - linrock/test60/test60-2021-11-nov-12tb7p.min-v2.binpack
+  - linrock/test60/test60-2021-12-dec-12tb7p.min-v2.binpack
+  - linrock/test77/test77-2021-12-dec-16tb7p.v6-dd.min.binpack
+  - linrock/test78/test78-2022-01-to-05-jantomay-16tb7p.v6-dd.min.binpack
+  - linrock/test79/test79-2022-04-apr-16tb7p.v6-dd.min.binpack
+  - linrock/test79/test79-2022-05-may-16tb7p.v6-dd.min.binpack
+  - linrock/test78/test78-2022-06-to-09-juntosep-16tb7p.v6-dd.min.binpack
+  - linrock/test80-2022/test80-2022-06-jun-16tb7p.v6-dd.min.binpack
+  - linrock/test80-2022/test80-2022-07-jul-16tb7p.v6-dd.min.binpack
+  - linrock/test80-2022/test80-2022-08-aug-16tb7p.v6-dd.min.binpack
+  - linrock/test80-2022/test80-2022-09-sep-16tb7p.v6-dd.min.binpack
+  - linrock/test80-2022/test80-2022-10-oct-16tb7p.v6-dd.binpack
+  - linrock/test80-2022/test80-2022-11-nov-16tb7p.v6-dd.min.binpack
+  - linrock/test80-2023/test80-2023-01-jan-16tb7p.v6-sk20.min.binpack
+  - linrock/test80-2023/test80-2023-02-feb-16tb7p.v6-dd.min.binpack
+  - linrock/test80-2023/test80-2023-03-mar-2tb7p.v6-sk16.min.binpack
+  - linrock/test80-2023/test80-2023-04-apr-2tb7p.v6-sk16.min.binpack
+  - linrock/test80-2023/test80-2023-05-may-2tb7p.v6.min.binpack
+  - linrock/test80-2023/test80-2023-06-jun-2tb7p.min-v2.v6.binpack
+  - linrock/test80-2023/test80-2023-07-jul-2tb7p.min-v2.v6.binpack
+  - linrock/test80-2023/test80-2023-08-aug-2tb7p.v6.min.binpack
+  - linrock/test80-2023/test80-2023-09-sep-2tb7p.min-v2.v6.binpack
+  - linrock/test80-2023/test80-2023-10-oct-2tb7p.min-v2.v6.binpack
+  - linrock/test80-2023/test80-2023-11-nov-2tb7p.min-v2.v6.binpack
+  - linrock/test80-2023/test80-2023-12-dec-2tb7p.min-v2.v6.binpack
+  - linrock/test80-2024/test80-2024-01-jan-2tb7p.min-v2.v6.binpack
+  - linrock/test80-2024/test80-2024-02-feb-2tb7p.min-v2.v6.binpack
+  - linrock/test80-2024/test80-2024-03-mar-2tb7p.min-v2.v6.binpack
+  - linrock/test80-2024/test80-2024-04-apr-2tb7p.min-v2.v6.binpack
+  - linrock/test80-2024/test80-2024-05-may-2tb7p.min-v2.v6.binpack
+  - linrock/test80-2024/test80-2024-06-jun-2tb7p.min-v2.v6.binpack
+  - vondele/from_kaggle_2_relabel/T60T70wIsRightFarseerT60T74T75T76.split_0.relabel-BT4-tf13tune.binpack
+  - vondele/from_kaggle_2_relabel/T60T70wIsRightFarseerT60T74T75T76.split_1.relabel-BT4-tf13tune.binpack
+  - vondele/from_kaggle_2_relabel/T60T70wIsRightFarseerT60T74T75T76.split_2.relabel-BT4-tf13tune.binpack
+  - vondele/from_kaggle_2_relabel/T60T70wIsRightFarseerT60T74T75T76.split_3.relabel-BT4-tf13tune.binpack
+  - vondele/from_kaggle_2_relabel/T60T70wIsRightFarseerT60T74T75T76.split_4.relabel-BT4-tf13tune.binpack
+  - vondele/master-binpacks_relabel/nodes5000pv2_UHO.relabel-BT4-tf13tune.binpack
+  - anematode/bt4-relabel/wrongIsRight_nodes5000pv2-rescored.binpack
+  - vondele/master-binpacks_relabel/multinet_pv-2_diff-100_nodes-5000.relabel-BT4-tf13tune.binpack
+  - vondele/master-binpacks_relabel/dfrc_n5000.relabel-BT4-tf13tune.binpack
+  - vondele/rescored/tb5dtm.binpack
+
+fine_tuning_binpacks_lq: &fine_tuning_binpacks_lq
+  - vondele/from_kaggle_2_relabel/T60T70wIsRightFarseerT60T74T75T76.split_0.relabel-BT4-tf13tune.binpack
+  - vondele/from_kaggle_2_relabel/T60T70wIsRightFarseerT60T74T75T76.split_1.relabel-BT4-tf13tune.binpack
+  - vondele/from_kaggle_2_relabel/T60T70wIsRightFarseerT60T74T75T76.split_2.relabel-BT4-tf13tune.binpack
+  - vondele/from_kaggle_2_relabel/T60T70wIsRightFarseerT60T74T75T76.split_3.relabel-BT4-tf13tune.binpack
+  - vondele/from_kaggle_2_relabel/T60T70wIsRightFarseerT60T74T75T76.split_4.relabel-BT4-tf13tune.binpack
+  - vondele/master-binpacks_relabel/nodes5000pv2_UHO.relabel-BT4-tf13tune.binpack
+  - anematode/bt4-relabel/wrongIsRight_nodes5000pv2-rescored.binpack
+  - vondele/master-binpacks_relabel/multinet_pv-2_diff-100_nodes-5000.relabel-BT4-tf13tune.binpack
+  - vondele/master-binpacks_relabel/dfrc_n5000.relabel-BT4-tf13tune.binpack
+  - vondele/rescored/tb5dtm.binpack
+  - vondele/linrock_relabel_1/test60-2021-11-nov-12tb7p.min-v2.relabel-BT4-tf13tune.binpack
+  - vondele/linrock_relabel_1/test60-2021-12-dec-12tb7p.min-v2.relabel-BT4-tf13tune.binpack
+  - vondele/linrock_relabel_1/test77-2021-12-dec-16tb7p.v6-dd.min.relabel-BT4-tf13tune.binpack
+  - vondele/linrock_relabel_1/test78-2022-01-to-05-jantomay-16tb7p.v6-dd.min.relabel-BT4-tf13tune.binpack
+  - vondele/linrock_relabel_1/test79-2022-04-apr-16tb7p.v6-dd.min.relabel-BT4-tf13tune.binpack
+  - vondele/linrock_relabel_1/test79-2022-05-may-16tb7p.v6-dd.min.relabel-BT4-tf13tune.binpack
+  - vondele/linrock_relabel_1/test78-2022-06-to-09-juntosep-16tb7p.v6-dd.min.relabel-BT4-tf13tune.binpack
+  - vondele/linrock_relabel_1/test80-2022-06-jun-16tb7p.v6-dd.min.relabel-BT4-tf13tune.binpack
+  - vondele/linrock_relabel_1/test80-2022-07-jul-16tb7p.v6-dd.min.relabel-BT4-tf13tune.binpack
+  - vondele/linrock_relabel_1/test80-2022-08-aug-16tb7p.v6-dd.min.relabel-BT4-tf13tune.binpack
+  - vondele/linrock_relabel_1/test80-2022-09-sep-16tb7p.v6-dd.min.relabel-BT4-tf13tune.binpack
+  - vondele/linrock_relabel_1/test80-2022-10-oct-16tb7p.v6-dd.relabel-BT4-tf13tune.binpack
+  - vondele/linrock_relabel_1/test80-2022-11-nov-16tb7p.v6-dd.min.relabel-BT4-tf13tune.binpack
+  - vondele/linrock_relabel_2/test80-2023-01-jan-16tb7p.v6-sk20.min.relabel-BT4-tf13tune.binpack
+  - vondele/linrock_relabel_2/test80-2023-02-feb-16tb7p.v6-dd.min.relabel-BT4-tf13tune.binpack
+  - vondele/linrock_relabel_2/test80-2023-03-mar-2tb7p.v6-sk16.min.relabel-BT4-tf13tune.binpack
+  - vondele/linrock_relabel_2/test80-2023-04-apr-2tb7p.v6-sk16.min.relabel-BT4-tf13tune.binpack
+  - vondele/linrock_relabel_2/test80-2023-05-may-2tb7p.v6.min.relabel-BT4-tf13tune.binpack
+  - vondele/linrock_relabel_2/test80-2023-06-jun-2tb7p.min-v2.v6.relabel-BT4-tf13tune.binpack
+  - vondele/linrock_relabel_2/test80-2023-07-jul-2tb7p.min-v2.v6.relabel-BT4-tf13tune.binpack
+  - vondele/linrock_relabel_2/test80-2023-08-aug-2tb7p.v6.min.relabel-BT4-tf13tune.binpack
+  - vondele/linrock_relabel_2/test80-2023-09-sep-2tb7p.min-v2.v6.relabel-BT4-tf13tune.binpack
+  - vondele/linrock_relabel_2/test80-2023-10-oct-2tb7p.min-v2.v6.relabel-BT4-tf13tune.binpack
+  - vondele/linrock_relabel_2/test80-2023-11-nov-2tb7p.min-v2.v6.relabel-BT4-tf13tune.binpack
+  - vondele/linrock_relabel_2/test80-2023-12-dec-2tb7p.min-v2.v6.relabel-BT4-tf13tune.binpack
+  - vondele/linrock_relabel_2/test80-2023-12-dec-2tb7p.min-v2.v6.relabel-BT4-tf13tune.binpack
+  - xushawn/test80-bt4-relabel/test80-2024-01-jan-2tb7p.min-v2.v6.relabel.binpack
+  - xushawn/test80-bt4-relabel/test80-2024-02-feb-2tb7p.min-v2.v6.relabel.binpack
+
+model_config: &model_config
+  features: Full_Threats+HalfKAv2_hm^
+  l1: 1024
+  l2: 32
+
+optimize_flags: &optimize_flags
+  <<: *model_config
+  ft-optimize-count: 100000
+  ft-optimize: true
+  ft-compression: leb128
+
+checkpoint2nnue_options: &checkpoint2nnue_options
+  <<: *model_config
+  ft-compression: leb128
+
+common_run_options: &common_run_options
+  optimizer-name: rangerlite
+  validation-size: 250000000
+  check-val-every-n-epoch: 50
+  batch-size: 131072
+  <<: *model_config
+  factorized-weight-decay: 0.001
+  random-fen-skipping: 10
+  early-fen-skipping: 18
+  soft-early-fen_skipping: 32
+  pc-y0: -0.20
+  pc-y1: 0.45
+  pc-y2: 1.0
+  pc-y3: 0.95
+  pc-y4: 0.75
+
+warmups_stage_options: &warmups_stage_options
+  ply-x1: 0.0
+  ply-y1: 0.01
+  ply-x2: 14.0
+  ply-y2: 0.20
+  ply-x3: 18.5
+  ply-y3: 0.50
+  ply-x4: 29.5
+  ply-y4: 0.80
+  one-cycle-warmup-pct: 0.5
+  one-cycle-final-div: "4e0"
+  start-lambda: 1.0
+  end-lambda: 0.70
+
+advanced_stage_options: &advanced_stage_options
+  ply-x1: 0.00
+  ply-y1: 0.025
+  ply-x2: 22.0
+  ply-y2: 0.05
+  ply-x3: 25.5
+  ply-y3: 0.20
+  ply-x4: 29.5
+  ply-y4: 0.80
+  pow-exp: 2.4340402395048404
+  qp-asymmetry: 0.22866886710086187
+  in-scaling: 295.6539508488627
+  out-scaling: 379.98724077106635
+  in-offset: 285.2706341467852
+  out-offset: 289.1258344152218
+  one-cycle-warmup-pct: 0.033
+  one-cycle-final-div: "2e3"
+  jitter-lambda-sample: 0.0034284671121657256
+  jitter-lambda-batch: 0.0061980291754002
+  jitter-decay-lambda-batch: 0.999
+  start-lambda: 0.7401424425915776
+  end-lambda: 0.7401424425915776
+
+trainer: &trainer
+  owner: TonyCongqianWang
+  sha: 6cd6ed4e6de7a6bb260e60f1cde02464b3049212
+
+reference_code: &reference_code
+  owner: TonyCongqianWang
+  sha: 82d79197e1abd7994571a16dc1f4e41031645529
+  target: profile-build
+
+testing_code: &testing_code
+  <<: *reference_code
+
+# --- Grouped Structure Anchors for Redundancy Reduction ---
+common_convert: &common_convert
+  binpack: official-stockfish/master-binpacks/fishpack32.binpack
+  checkpoint2nnue: *checkpoint2nnue_options
+  optimize: *optimize_flags
+
+common_step: &common_step
+  convert: *common_convert
+  trainer: *trainer
+
+common_run_resume_model: &common_run_resume_model
+  repetitions: 1
+  resume: previous_model
+
+common_run_resume_ckpt: &common_run_resume_ckpt
+  <<: *common_run_resume_model
+  resume: previous_checkpoint
+
+# ----------------------------------------------------------
+
+testing:
+  crosscheck:
+    trainer: *trainer
+    binpack: official-stockfish/master-binpacks/fishpack32.binpack
+    other_options:
+      <<: *model_config
+      count: 20000
+  fastchess:
+    code:
+      owner: Disservin
+      sha: b9008d08b9f375ef7810dc55da6ff223a3992cc2
+    options:
+      hash: 16
+      max_rounds: 100
+      tc: 10+0.1
+  reference:
+    code: *reference_code
+  steps: 4
+  testing:
+    code: *testing_code
+
+
+training:
+  steps:
+    # Stage 1
+    - <<: *common_step
+      run:
+        binpacks: *pretraining_binpacks_lq
+        max_epochs: 500
+        other_options:
+          <<: [*common_run_options, *warmups_stage_options]
+          one-cycle-steps: 190750
+          swa-start-epoch: 400
+          lr: "0.8e-3"
+        repetitions: 1
+        resume: none
+
+    # Stage 2
+    - <<: *common_step
+      run:
+        <<: *common_run_resume_model
+        binpacks: *pretraining_binpacks_lq
+        max_epochs: 2000
+        other_options:
+          <<: [*common_run_options, *advanced_stage_options]
+          one-cycle-steps: 3509800
+          lr: "0.9e-3"
+
+    # Stage 3
+    - <<: *common_step
+      run:
+        <<: *common_run_resume_ckpt
+        binpacks: *pretraining_binpacks_hq
+        max_epochs: 3600
+        other_options:
+          <<: [*common_run_options, *advanced_stage_options]
+          one-cycle-steps: 3509800
+          lr: "0.9e-3"
+
+    # Stage 4
+    - <<: *common_step
+      trainer: *trainer
+      run:
+        <<: *common_run_resume_ckpt
+        binpacks: *fine_tuning_binpacks_lq
+        max_epochs: 3900
+        other_options:
+          <<: [*common_run_options, *advanced_stage_options]
+          one-cycle-steps: 3509800
+          lr: "0.9e-3"
+          batch_size: 65536
+          start-lambda: 1
+          end-lambda: 1
+          jitter-lambda-sample: 0.0
+          jitter-lambda-batch: 0.0
+          jitter-decay-lambda-batch: 0.0


### PR DESCRIPTION
I suppose now mutli recipe would be handy but its really just an edge case

both recipes already ran in the past, this is to see if the loss params qp_asymmetry or w1, w2 actually affect matetrack performance
