### PR TITLE
Smallnet for web analysis for next SF release

### DIFF
--- a/testing.yaml
+++ b/testing.yaml
@@ -1,5 +1,5 @@
 optimize_flags: &optimize_flags
-  features: Full_Threats+PP_3Wide+HalfKAv2_hm^
+  features: P_hm
   l1: 1024
   l2: 32
   ft-optimize-count: 100000
@@ -7,7 +7,7 @@ optimize_flags: &optimize_flags
   ft-compression: leb128
 
 checkpoint2nnue_options: &checkpoint2nnue_options
-  features: Full_Threats+PP_3Wide+HalfKAv2_hm^
+  features: P_hm
   l1: 1024
   l2: 32
   ft-compression: leb128
@@ -15,7 +15,7 @@ checkpoint2nnue_options: &checkpoint2nnue_options
 common_run_options: &common_run_options
   batch-size: 8192
   epoch-size: 100000
-  features: Full_Threats+PP_3Wide+HalfKAv2_hm^
+  features: P_hm
   l1: 1024
   l2: 32
   random-fen-skipping: 10
@@ -30,7 +30,7 @@ common_run_options: &common_run_options
 
 trainer: &trainer
   owner: sscg13
-  sha: 8e85dbaf5bc695c1e9cf42863b5a2f7777acb064
+  sha: 1a81735b332898ad0ffc73021b1842a729fc2973
 
 # --- Grouped Structure Anchors for Redundancy Reduction ---
 common_convert: &common_convert
@@ -49,7 +49,7 @@ official_code: &official_code
 
 engine: &engine
   owner: sscg13
-  sha: 77399c0314ac7af6ad65f174557cac685926fb30
+  sha: f8b5062a4f61cc6ec87d20e16c72c7771ea13dee
   target: profile-build
 # ----------------------------------------------------------
 
@@ -58,7 +58,7 @@ testing:
     trainer: *trainer
     binpack: official-stockfish/master-binpacks/fishpack32.binpack
     other_options:
-      features: Full_Threats+PP_3Wide+HalfKAv2_hm^
+      features: P_hm
       l1: 1024
       l2: 32
       count: 5000

--- a/threats.yaml
+++ b/threats.yaml
@@ -44,7 +44,7 @@ training_binpacks: &training_binpacks
   - vondele/rescored/tb5dtm.binpack
 
 model_config: &model_config
-  features: Full_Threats+PP_3Wide+HalfKAv2_hm^
+  features: P_hm
   l1: 1024
   l2: 32
 
@@ -102,8 +102,8 @@ advanced_stage_options: &advanced_stage_options
   lambda-cycle-delta: -0.3
 
 trainer: &trainer
-  owner: official-stockfish
-  sha: 9f72946529c4187d3679014036cd22c3be419716
+  owner: sscg13
+  sha: 1a81735b332898ad0ffc73021b1842a729fc2973
 
 reference_code: &reference_code
   owner: official-stockfish
@@ -111,8 +111,8 @@ reference_code: &reference_code
   target: profile-build
 
 testing_code: &testing_code
-  owner: official-stockfish
-  sha: 23cf5d827388e84d4389b40025ef401db4925f25
+  owner: sscg13
+  sha: f8b5062a4f61cc6ec87d20e16c72c7771ea13dee
   target: profile-build
 
 # --- Grouped Structure Anchors for Redundancy Reduction ---


### PR DESCRIPTION
Special size-optimized input features, intends to target the elo of "SF 18 15MB" while only using 1-2MB
Not intended for testing vs SF master